### PR TITLE
More Test Fixes

### DIFF
--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -817,7 +817,7 @@ defmodule Blockchain.Block do
       iex> Enum.count(block.transactions)
       1
       iex> Blockchain.Block.get_receipt(block, 0, db)
-      %Blockchain.Transaction.Receipt{bloom_filter: "", cumulative_gas: 53780, logs: "", state: block.header.state_root}
+      %Blockchain.Transaction.Receipt{bloom_filter: "", cumulative_gas: 53780, logs: [], state: block.header.state_root}
       iex> Blockchain.Block.get_transaction(block, 0, db)
       %Blockchain.Transaction{data: "", gas_limit: 100000, gas_price: 3, init: <<96, 3, 96, 5, 1, 96, 0, 82, 96, 32, 96, 0, 243>>, nonce: 5, r: 107081699003708865501096995082166450904153826331883689397382301082384794234940, s: 15578885506929783846367818105804923093083001199223955674477534036059482186127, to: "", v: 27, value: 5}
       iex> Blockchain.Block.get_state(block, db)

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -280,7 +280,7 @@ defmodule Blockchain.Transaction do
       ...> |> Blockchain.Account.put_account(sender, %Blockchain.Account{balance: 400_000, nonce: 5})
       ...> |> Blockchain.Transaction.execute_transaction(trx, %Block.Header{beneficiary: beneficiary})
       iex> {gas, logs}
-      {53780, <<>>}
+      {53780, []}
       iex> Blockchain.Account.get_accounts(state, [sender, beneficiary, contract_address])
       [%Blockchain.Account{balance: 238655, nonce: 6}, %Blockchain.Account{balance: 161340}, %Blockchain.Account{balance: 5, code_hash: <<243, 247, 169, 254, 54, 79, 170, 185, 59, 33, 109, 165, 10, 50, 20, 21, 79, 34, 160, 162, 180, 21, 178, 58, 132, 200, 22, 158, 139, 99, 110, 227>>}]
 
@@ -297,7 +297,7 @@ defmodule Blockchain.Transaction do
       ...> |> Blockchain.Account.put_code(contract_address, machine_code)
       ...> |> Blockchain.Transaction.execute_transaction(trx, %Block.Header{beneficiary: beneficiary})
       iex> {gas, logs}
-      {21780, <<>>}
+      {21780, []}
       iex> Blockchain.Account.get_accounts(state, [sender, beneficiary, contract_address])
       [%Blockchain.Account{balance: 334655, nonce: 6}, %Blockchain.Account{balance: 65340}, %Blockchain.Account{balance: 5, code_hash: <<216, 114, 80, 103, 17, 50, 164, 75, 162, 123, 123, 99, 162, 105, 226, 15, 215, 200, 136, 216, 29, 106, 193, 119, 1, 173, 138, 37, 219, 39, 23, 231>>}]
   """

--- a/apps/blockchain/test/blockchain/block_test.exs
+++ b/apps/blockchain/test/blockchain/block_test.exs
@@ -21,7 +21,7 @@ defmodule Blockchain.BlockTest do
         gas_limit: test["gasLimit"] |> maybe_hex,
         difficulty: test["difficulty"] |> maybe_hex,
         author: test["coinbase"] |> maybe_hex,
-        mix_hash: test["mixhash"] |> maybe_hex,
+        mix_hash: test["mixHash"] |> maybe_hex,
         nonce: test["nonce"] |> maybe_hex
       },
       accounts: get_test_accounts(test["alloc"])

--- a/apps/blockchain/test/blockchain/transaction_test.exs
+++ b/apps/blockchain/test/blockchain/transaction_test.exs
@@ -187,7 +187,7 @@ defmodule Blockchain.TransactionTest do
         })
 
       assert gas_used == 53004
-      assert logs == ""
+      assert logs == []
 
       assert Blockchain.Account.get_accounts(state, [sender, beneficiary, contract_address]) ==
                [

--- a/apps/ex_wire/lib/ex_wire/packet/new_block.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/new_block.ex
@@ -77,7 +77,7 @@ defmodule ExWire.Packet.NewBlock do
       ...> |> ExWire.Packet.NewBlock.deserialize()
       %ExWire.Packet.NewBlock{
         block_header: %Block.Header{parent_hash: <<1::256>>, ommers_hash: <<2::256>>, beneficiary: <<3::160>>, state_root: <<4::256>>, transactions_root: <<5::256>>, receipts_root: <<6::256>>, logs_bloom: <<>>, difficulty: 5, number: 1, gas_limit: 5, gas_used: 3, timestamp: 6, extra_data: "Hi mom", mix_hash: <<7::256>>, nonce: <<8::64>>},
-        block: %ExWire.Struct.Block{transactions_list: [], ommers: []},
+        block: %ExWire.Struct.Block{transactions: [], ommers: [], transactions_list: []},
         total_difficulty: 10
       }
   """

--- a/apps/ex_wire/lib/ex_wire/struct/block_queue.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/block_queue.ex
@@ -54,13 +54,13 @@ defmodule ExWire.Struct.BlockQueue do
 
       iex> chain = Blockchain.Test.ropsten_chain()
       iex> db = MerklePatriciaTree.Test.random_ets_db(:proces_block_queue)
-      iex> header = %Block.Header{number: 5, parent_hash: <<0::256>>, beneficiary: <<2, 3, 4>>, difficulty: 100, timestamp: 11, mix_hash: <<1>>, nonce: <<2>>}
+      iex> header = %Block.Header{number: 0, parent_hash: <<0::256>>, beneficiary: <<2, 3, 4>>, difficulty: 100, timestamp: 11, mix_hash: <<1>>, nonce: <<2>>}
       iex> header_hash = <<78, 28, 127, 10, 192, 253, 127, 239, 254, 179, 39, 34, 245, 44, 152, 98, 128, 71, 238, 155, 100, 161, 199, 71, 243, 223, 172, 191, 74, 99, 128, 63>>
       iex> {block_queue, block_tree, false} = ExWire.Struct.BlockQueue.add_header_to_block_queue(%ExWire.Struct.BlockQueue{do_validation: false}, Blockchain.Blocktree.new_tree(), header, header_hash, "remote_id", chain, db)
       iex> block_queue.queue
       %{}
       iex> block_tree.parent_map
-      %{<<109, 191, 166, 180, 1, 44, 85, 48, 107, 43, 51, 4, 81, 128, 110, 188, 130, 1, 5, 255, 21, 204, 250, 214, 105, 55, 182, 104, 0, 94, 102, 6>> => <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>}
+      %{<<52, 135, 4, 5, 74, 2, 167, 221, 88, 74, 64, 210, 209, 25, 208, 14, 187, 181, 226, 234, 205, 235, 150, 211, 109, 83, 167, 23, 94, 231, 29, 232>> => <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>}
 
       # TODO: Add a second addition example
   """
@@ -214,7 +214,7 @@ defmodule ExWire.Struct.BlockQueue do
 
       iex> chain = Blockchain.Test.ropsten_chain()
       iex> db = MerklePatriciaTree.Test.random_ets_db(:process_block_queue)
-      iex> header = %Block.Header{number: 1, parent_hash: <<0::256>>, beneficiary: <<2, 3, 4>>, difficulty: 100, timestamp: 11, mix_hash: <<1>>, nonce: <<2>>}
+      iex> header = %Block.Header{number: 0, parent_hash: <<0::256>>, beneficiary: <<2, 3, 4>>, difficulty: 100, timestamp: 11, mix_hash: <<1>>, nonce: <<2>>}
       iex> {block_queue, block_tree} = %ExWire.Struct.BlockQueue{
       ...>   queue: %{
       ...>     1 => %{
@@ -230,7 +230,7 @@ defmodule ExWire.Struct.BlockQueue do
       ...> }
       ...> |> ExWire.Struct.BlockQueue.process_block_queue(Blockchain.Blocktree.new_tree(), chain, db)
       iex> block_tree.parent_map
-      %{<<226, 210, 216, 149, 139, 194, 100, 151, 35, 86, 131, 75, 10, 203, 201, 20, 232, 134, 23, 195, 24, 34, 181, 6, 142, 4, 57, 85, 121, 223, 246, 87>> => <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>}
+      %{<<52, 135, 4, 5, 74, 2, 167, 221, 88, 74, 64, 210, 209, 25, 208, 14, 187, 181, 226, 234, 205, 235, 150, 211, 109, 83, 167, 23, 94, 231, 29, 232>> => <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>}
       iex> block_queue.queue
       %{}
   """

--- a/apps/ex_wire/test/ex_wire/packet/new_block_test.exs
+++ b/apps/ex_wire/test/ex_wire/packet/new_block_test.exs
@@ -1,4 +1,5 @@
 defmodule ExWire.Packet.NewBlockTest do
   use ExUnit.Case, async: true
   doctest ExWire.Packet.NewBlock
+
 end

--- a/apps/ex_wire/test/ex_wire/struct/block_queue_test.exs
+++ b/apps/ex_wire/test/ex_wire/struct/block_queue_test.exs
@@ -1,4 +1,5 @@
 defmodule ExWire.Struct.BlockQueueTest do
   use ExUnit.Case, async: true
   doctest ExWire.Struct.BlockQueue
+
 end


### PR DESCRIPTION
This patch fixes the remaining test cases that were breaking. The changes were mostly some minor changes that occured between different versions of the sub-projects that came out since being unified. The only remaining tests to fix are in `transaction_test` which are ethereum common tests that have moved.