### PR TITLE
Credo fixes refactoring

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -107,7 +107,7 @@
         {Credo.Check.Refactor.NegatedConditionsInUnless},
         {Credo.Check.Refactor.NegatedConditionsWithElse},
         {Credo.Check.Refactor.Nesting},
-        {Credo.Check.Refactor.PipeChainStart},
+        {Credo.Check.Refactor.PipeChainStart, false},
         {Credo.Check.Refactor.UnlessWithElse},
         {Credo.Check.Warning.BoolOperationOnSameValues},
         {Credo.Check.Warning.ExpensiveEmptyEnumCheck},

--- a/apps/abi/lib/abi/parser.ex
+++ b/apps/abi/lib/abi/parser.ex
@@ -3,13 +3,13 @@ defmodule ABI.Parser do
 
   @doc false
   def parse!(str, opts \\ []) do
-    {:ok, tokens, _} = str |> String.to_charlist() |> :ethereum_abi_lexer.string()
+    {:ok, tokens0, _} = str |> String.to_charlist() |> :ethereum_abi_lexer.string()
 
     tokens =
       case opts[:as] do
-        nil -> tokens
-        :type -> [{:"expecting type", 1} | tokens]
-        :selector -> [{:"expecting selector", 1} | tokens]
+        nil -> tokens0
+        :type -> [{:"expecting type", 1} | tokens0]
+        :selector -> [{:"expecting selector", 1} | tokens0]
       end
 
     {:ok, ast} = :ethereum_abi_parser.parse(tokens)

--- a/apps/abi/lib/abi/type_decoder.ex
+++ b/apps/abi/lib/abi/type_decoder.ex
@@ -183,8 +183,8 @@ defmodule ABI.TypeDecoder do
   end
 
   defp decode_type(:string, data) do
-    {string_size_in_bytes, rest} = decode_uint(data, 256)
-    {raw_bytes, rest} = decode_bytes(rest, string_size_in_bytes, :right)
+    {string_size_in_bytes, rest0} = decode_uint(data, 256)
+    {raw_bytes, rest} = decode_bytes(rest0, string_size_in_bytes, :right)
     {nul_terminate_string(raw_bytes), rest}
   end
 
@@ -216,7 +216,7 @@ defmodule ABI.TypeDecoder do
 
   defp decode_type({:tuple, types}, starting_data) do
     # First pass, decode static types
-    {elements, rest} =
+    {elements0, rest0} =
       Enum.reduce(types, {[], starting_data}, fn type, {elements, data} ->
         if ABI.FunctionSelector.is_dynamic?(type) do
           {tail_position, rest} = decode_type({:uint, 256}, data)
@@ -231,7 +231,7 @@ defmodule ABI.TypeDecoder do
 
     # Second pass, decode dynamic types
     {elements, rest} =
-      Enum.reduce(elements |> Enum.reverse(), {[], rest}, fn el, {elements, data} ->
+      Enum.reduce(elements0 |> Enum.reverse(), {[], rest0}, fn el, {elements, data} ->
         case el do
           {:dynamic, type, _tail_position} ->
             {el, rest} = decode_type(type, data)

--- a/apps/blockchain/lib/blockchain/block.ex
+++ b/apps/blockchain/lib/blockchain/block.ex
@@ -913,7 +913,7 @@ defmodule Blockchain.Block do
   """
   @spec put_transaction(t, integer(), Transaction.t(), DB.db()) :: t
   def put_transaction(block, i, trx, db) do
-    total_transactions = block.transactions ++ [trx]
+    total_transactions = Enum.concat(block.transactions, [trx])
 
     updated_transactions_root =
       Trie.new(db, block.header.transactions_root)

--- a/apps/blockchain/lib/blockchain/contract.ex
+++ b/apps/blockchain/lib/blockchain/contract.ex
@@ -5,7 +5,25 @@ defmodule Blockchain.Contract do
   Λ and Θ, as defined in Eq.(70) and described in detail
   in sections 7 and 8 of the Yellow Paper.
   """
+  defstruct state: nil,
+            sender: %{},
+            originator: %{},
+            available_gas: %{},
+            gas_price: [],
+            stack_depth: 0,
+            block_header: nil,
+            value_in_wei: nil
 
+  @type t :: %__MODULE__{
+          state: EVM.state(),
+          sender: EVM.address(),
+          originator: EVM.address(),
+          available_gas: EVM.Gas.t(),
+          gas_price: EVM.Gas.gas_price(),
+          stack_depth: integer(),
+          block_header: Header.t(),
+          value_in_wei: EVM.Wei.t()
+        }
   alias Blockchain.Account
   alias EVM.Block.Header
 
@@ -21,42 +39,43 @@ defmodule Blockchain.Contract do
   ## Examples
 
       iex> db = MerklePatriciaTree.Test.random_ets_db(:contract_create_test)
-      iex> {state, _gas, _sub_state} = MerklePatriciaTree.Trie.new(db)
-      ...> |> Blockchain.Account.put_account(<<0x10::160>>, %Blockchain.Account{balance: 11, nonce: 5})
-      ...> |> Blockchain.Contract.create_contract(<<0x10::160>>, <<0x10::160>>, 1000, 1, 5, EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 32, :push1, 0, :return]), 5, %EVM.Block.Header{nonce: 1})
+      iex> state = MerklePatriciaTree.Trie.new(db)
+      iex> state = Blockchain.Account.put_account(state, <<0x10::160>>, %Blockchain.Account{balance: 11, nonce: 5})
+      iex> endowment = 5
+      iex> contract = %Blockchain.Contract{state: state, sender: <<0x10::160>>, originator: <<0x10::160>>, available_gas: 1000, gas_price: 1, stack_depth: 5, block_header: %EVM.Block.Header{nonce: 1}, value_in_wei: endowment }
+      iex> init_code = EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 32, :push1, 0, :return])
+      iex> {resultant_state, _resultant_gas, _accrued_sub_state} = Blockchain.Contract.create_contract(contract, init_code)
       {
         %MerklePatriciaTree.Trie{db: {MerklePatriciaTree.DB.ETS, :contract_create_test}, root_hash: <<9, 235, 32, 146, 153, 242, 209, 192, 224, 61, 214, 174, 48, 24, 148, 28, 51, 254, 7, 82, 58, 82, 220, 157, 29, 159, 203, 51, 52, 240, 37, 122>>},
         976,
         %EVM.SubState{}
       }
-      iex> Blockchain.Account.get_accounts(state, [<<0x10::160>>, Blockchain.Contract.new_contract_address(<<0x10::160>>, 5)])
+      iex> Blockchain.Account.get_accounts(resultant_state, [<<0x10::160>>, Blockchain.Contract.new_contract_address(<<0x10::160>>, 5)])
       [%Blockchain.Account{balance: 6, nonce: 5}, %Blockchain.Account{balance: 5, code_hash: <<243, 247, 169, 254, 54, 79, 170, 185, 59, 33, 109, 165, 10, 50, 20, 21, 79, 34, 160, 162, 180, 21, 178, 58, 132, 200, 22, 158, 139, 99, 110, 227>>}]
-      iex> Blockchain.Account.get_machine_code(state, Blockchain.Contract.new_contract_address(<<0x10::160>>, 5))
+      iex> Blockchain.Account.get_machine_code(resultant_state, Blockchain.Contract.new_contract_address(<<0x10::160>>, 5))
       {:ok, <<0x08::256>>}
-      iex> MerklePatriciaTree.Trie.Inspector.all_keys(state) |> Enum.count
+      iex> MerklePatriciaTree.Trie.Inspector.all_keys(resultant_state) |> Enum.count
       2
   """
+
   @spec create_contract(
-          EVM.state(),
-          EVM.address(),
-          EVM.address(),
-          EVM.Gas.t(),
-          EVM.Gas.gas_price(),
-          EVM.Wei.t(),
-          EVM.MachineCode.t(),
-          integer(),
-          Header.t()
+          t,
+          EVM.MachineCode.t()
         ) :: {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}
+
   def create_contract(
-        state,
-        sender,
-        originator,
-        available_gas,
-        gas_price,
-        endowment,
-        init_code,
-        stack_depth,
-        block_header
+        %__MODULE__{
+          state: state,
+          sender: sender,
+          originator: originator,
+          available_gas: available_gas,
+          gas_price: gas_price,
+          stack_depth: stack_depth,
+          block_header: block_header,
+          value_in_wei: endowment
+        },
+        # machine_code
+        init_code
       ) do
     sender_account = Account.get_account(state, sender)
     contract_address = new_contract_address(sender, sender_account.nonce)
@@ -118,11 +137,12 @@ defmodule Blockchain.Contract do
   ## Examples
 
       iex> db = MerklePatriciaTree.Test.random_ets_db(:message_call_test)
-      iex> {state, _gas, _sub_state, _output} = MerklePatriciaTree.Trie.new(db)
+      iex> state = MerklePatriciaTree.Trie.new(db)
       ...> |> Blockchain.Account.put_account(<<0x10::160>>, %Blockchain.Account{balance: 10})
       ...> |> Blockchain.Account.put_account(<<0x20::160>>, %Blockchain.Account{balance: 20})
       ...> |> Blockchain.Account.put_code(<<0x20::160>>, EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 32, :push1, 0, :return]))
-      ...> |> Blockchain.Contract.message_call(<<0x10::160>>, <<0x10::160>>, <<0x20::160>>, <<0x20::160>>, 1000, 1, 5, 5, <<1, 2, 3>>, 5, %EVM.Block.Header{nonce: 1})
+      ...> contract = %Blockchain.Contract{state: state, sender: <<0x10::160>>, originator: <<0x10::160>>, available_gas: 1000, gas_price: 1, stack_depth: 5, block_header: %EVM.Block.Header{nonce: 1}, value_in_wei: 5 }
+      ...> {state, _gas, _sub_state, _output} = Blockchain.Contract.message_call(contract, <<0x20::160>>, <<0x20::160>>, <<1, 2, 3>>, 5)
       {
         %MerklePatriciaTree.Trie{db: {MerklePatriciaTree.DB.ETS, :message_call_test}, root_hash: <<163, 151, 95, 0, 149, 63, 81, 220, 74, 101, 219, 175, 240, 97, 153, 167, 249, 229, 144, 75, 101, 233, 126, 177, 8, 188, 105, 165, 28, 248, 67, 156>>},
         976,
@@ -135,32 +155,27 @@ defmodule Blockchain.Contract do
       2
   """
   @spec message_call(
-          EVM.state(),
+          t,
           EVM.address(),
           EVM.address(),
-          EVM.address(),
-          EVM.address(),
-          EVM.Gas.t(),
-          EVM.Gas.gas_price(),
           EVM.Wei.t(),
-          EVM.Wei.t(),
-          binary(),
-          integer(),
-          Header.t()
+          binary()
         ) :: {EVM.state(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
   def message_call(
-        state,
-        sender,
-        originator,
+        %__MODULE__{
+          state: state,
+          sender: sender,
+          originator: originator,
+          available_gas: available_gas,
+          gas_price: gas_price,
+          stack_depth: stack_depth,
+          block_header: block_header,
+          value_in_wei: value
+        },
         recipient,
         contract,
-        available_gas,
-        gas_price,
-        value,
         apparent_value,
-        data,
-        stack_depth,
-        block_header
+        data
       ) do
     exec_fun = get_message_call_exec_fun(recipient)
 
@@ -211,26 +226,6 @@ defmodule Blockchain.Contract do
     |> ExRLP.encode()
     |> BitHelper.kec()
     |> BitHelper.mask_bitstring(160)
-  end
-
-  @doc """
-  Creates a blank contract prior to initialization code being run,
-  as defined in Eq.(83), Eq.(84) and Eq.(85) of the Yellow Paper.
-
-  We also indirectly cover Eq.(86)
-
-  ## Examples
-
-      iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
-      ...> |> Blockchain.Account.put_account(<<0x01::160>>, %Blockchain.Account{balance: 10})
-      ...> |> Blockchain.Contract.create_blank_contract(<<0x02::160>>, <<0x01::160>>, 6)
-      ...> |> Blockchain.Account.get_accounts([<<0x01::160>>, <<0x02::160>>])
-      [%Blockchain.Account{balance: 4}, %Blockchain.Account{balance: 6}]
-  """
-  @spec create_blank_contract(EVM.state(), EVM.address(), EVM.address(), EVM.Wei.t()) ::
-          EVM.state()
-  def create_blank_contract(state, contract_address, sender, endowment) do
-    Account.transfer!(state, sender, contract_address, endowment)
   end
 
   @doc """
@@ -428,4 +423,25 @@ defmodule Blockchain.Contract do
           {EVM.state(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
   defp interpret_vm_result({gas, sub_state, exec_env, output}),
     do: {exec_env.account_interface.state, gas, sub_state, output}
+
+  '''
+  Creates a blank contract prior to initialization code being run,
+  as defined in Eq.(83), Eq.(84) and Eq.(85) of the Yellow Paper.
+
+  We also indirectly cover Eq.(86)
+
+  ## Examples
+
+      iex> MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
+      ...> |> Blockchain.Account.put_account(<<0x01::160>>, %Blockchain.Account{balance: 10})
+      ...> |> Blockchain.Contract.create_blank_contract(<<0x02::160>>, <<0x01::160>>, 6)
+      ...> |> Blockchain.Account.get_accounts([<<0x01::160>>, <<0x02::160>>])
+      [%Blockchain.Account{balance: 4}, %Blockchain.Account{balance: 6}]
+  '''
+
+  @spec create_blank_contract(EVM.state(), EVM.address(), EVM.address(), EVM.Wei.t()) ::
+          EVM.state()
+  defp create_blank_contract(state, contract_address, sender, endowment) do
+    Account.transfer!(state, sender, contract_address, endowment)
+  end
 end

--- a/apps/blockchain/lib/blockchain/contract.ex
+++ b/apps/blockchain/lib/blockchain/contract.ex
@@ -59,12 +59,12 @@ defmodule Blockchain.Contract do
   """
 
   @spec create_contract(
-          t,
+          t | map,
           EVM.MachineCode.t()
         ) :: {EVM.state(), EVM.Gas.t(), EVM.SubState.t()}
 
   def create_contract(
-        %__MODULE__{
+        %{
           state: state,
           sender: sender,
           originator: originator,

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -34,6 +34,8 @@ defmodule Blockchain.Interface.AccountInterface do
 end
 
 defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterface do
+  alias Blockchain.Contract
+
   @doc """
   Given an account interface and an address, returns the balance at that address.
 
@@ -276,57 +278,59 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
   ## Examples
 
       iex> db = MerklePatriciaTree.Test.random_ets_db()
-      iex> {account_interface, _gas, _sub_state, _output} = MerklePatriciaTree.Trie.new(db)
+      iex> state = MerklePatriciaTree.Trie.new(db)
       ...> |> Blockchain.Account.put_account(<<0x10::160>>, %Blockchain.Account{balance: 10})
       ...> |> Blockchain.Account.put_account(<<0x20::160>>, %Blockchain.Account{balance: 20})
       ...> |> Blockchain.Account.put_code(<<0x20::160>>, EVM.MachineCode.compile([:push1, 3, :push1, 5, :add, :push1, 0x00, :mstore, :push1, 32, :push1, 0, :return]))
-      ...> |> Blockchain.Interface.AccountInterface.new()
-      ...> |> EVM.Interface.AccountInterface.message_call(<<0x10::160>>, <<0x10::160>>, <<0x20::160>>, <<0x20::160>>, 1000, 1, 5, 5, <<1, 2, 3>>, 5, %EVM.Block.Header{nonce: 1})
+      ...> account_interface =  Blockchain.Interface.AccountInterface.new(state)
+      ...> contract = %Blockchain.Contract{state: state, sender: <<0x10::160>>, originator: <<0x10::160>>, available_gas: 1000, gas_price: 1, stack_depth: 5, block_header: %EVM.Block.Header{nonce: 1}, value_in_wei: 5}
+      ...> {account_interface, _gas, _sub_state, _output} = EVM.Interface.AccountInterface.message_call(account_interface, contract, <<0x20::160>>, <<0x20::160>>, <<1, 2, 3>>, 5)
       iex> account_interface.state.root_hash
       <<163, 151, 95, 0, 149, 63, 81, 220, 74, 101, 219, 175, 240, 97, 153, 167, 249, 229, 144, 75, 101, 233, 126, 177, 8, 188, 105, 165, 28, 248, 67, 156>>
   """
   @spec message_call(
           EVM.Interface.AccountInterface.t(),
+          Contract.t(),
           EVM.address(),
           EVM.address(),
-          EVM.address(),
-          EVM.address(),
-          EVM.Gas.t(),
-          EVM.Gas.gas_price(),
           EVM.Wei.t(),
-          EVM.Wei.t(),
-          binary(),
-          integer(),
-          Header.t()
+          binary()
         ) :: {EVM.Interface.AccountInterface.t(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
   def message_call(
         account_interface,
-        sender,
-        originator,
+        %Contract{
+          state: _,
+          sender: sender,
+          originator: originator,
+          available_gas: available_gas,
+          gas_price: gas_price,
+          stack_depth: stack_depth,
+          block_header: block_header,
+          value_in_wei: value
+        },
         recipient,
         contract,
-        available_gas,
-        gas_price,
-        value,
         apparent_value,
-        data,
-        stack_depth,
-        block_header
+        data
       ) do
+    contract0 = %Contract{
+      state: account_interface.state,
+      sender: sender,
+      originator: originator,
+      available_gas: available_gas,
+      gas_price: gas_price,
+      stack_depth: stack_depth,
+      block_header: block_header,
+      value_in_wei: value
+    }
+
     {state, gas, sub_state, output} =
-      Blockchain.Contract.message_call(
-        account_interface.state,
-        sender,
-        originator,
+      Contract.message_call(
+        contract0,
         recipient,
         contract,
-        available_gas,
-        gas_price,
-        value,
         apparent_value,
-        data,
-        stack_depth,
-        block_header
+        data
       )
 
     {Map.put(account_interface, :state, state), gas, sub_state, output}
@@ -367,17 +371,21 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
         stack_depth,
         block_header
       ) do
+    contract = %Contract{
+      state: account_interface.state,
+      sender: sender,
+      originator: originator,
+      available_gas: available_gas,
+      gas_price: gas_price,
+      stack_depth: stack_depth,
+      block_header: block_header,
+      value_in_wei: endowment
+    }
+
     {state, gas, sub_state} =
-      Blockchain.Contract.create_contract(
-        account_interface.state,
-        sender,
-        originator,
-        available_gas,
-        gas_price,
-        endowment,
-        init_code,
-        stack_depth,
-        block_header
+      Contract.create_contract(
+        contract,
+        init_code
       )
 
     {Map.put(account_interface, :state, state), gas, sub_state}

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -6,6 +6,7 @@ defmodule Blockchain.Transaction do
   """
 
   alias Blockchain.Account
+  alias Blockchain.Contract
   alias EVM.Block.Header
 
   defstruct nonce: 0,
@@ -323,35 +324,43 @@ defmodule Blockchain.Transaction do
       case trx.to do
         # Λ
         <<>> ->
-          Blockchain.Contract.create_contract(
-            state_0,
-            sender,
-            originator,
-            gas,
-            trx.gas_price,
-            trx.value,
-            trx.init,
-            stack_depth,
-            block_header
+          contract = %Contract{
+            state: state_0,
+            sender: sender,
+            originator: originator,
+            available_gas: gas,
+            gas_price: trx.gas_price,
+            stack_depth: stack_depth,
+            block_header: block_header,
+            value_in_wei: trx.value
+          }
+
+          Contract.create_contract(
+            contract,
+            trx.init
           )
 
         recipient ->
           # Note, we only want to take the first 3 items from the tuples, as designated Θ_3 in the literature
           # Θ_3
+          contract = %Contract{
+            state: state_0,
+            sender: sender,
+            originator: originator,
+            available_gas: gas,
+            gas_price: trx.gas_price,
+            stack_depth: stack_depth,
+            block_header: block_header,
+            value_in_wei: trx.value
+          }
+
           {state, remaining_gas_, sub_state_, _output} =
-            Blockchain.Contract.message_call(
-              state_0,
-              sender,
-              originator,
+            Contract.message_call(
+              contract,
               recipient,
               recipient,
-              gas,
-              trx.gas_price,
-              trx.value,
               apparent_value,
-              trx.data,
-              stack_depth,
-              block_header
+              trx.data
             )
 
           {state, remaining_gas_, sub_state_}

--- a/apps/blockchain/lib/blockchain/transaction/signature.ex
+++ b/apps/blockchain/lib/blockchain/transaction/signature.ex
@@ -74,15 +74,15 @@ defmodule Blockchain.Transaction.Signature do
   @spec sign_hash(BitHelper.keccak_hash(), private_key, integer() | nil) ::
           {hash_v, hash_r, hash_s}
   def sign_hash(hash, private_key, chain_id \\ nil) do
-    {:ok, <<r::size(256), s::size(256)>>, recovery_id} =
+    {:ok, <<r::size(256), s::size(256)>>, recovery_id0} =
       :libsecp256k1.ecdsa_sign_compact(hash, private_key, :default, <<>>)
 
     # Fork Ψ EIP-155
     recovery_id =
       if chain_id do
-        chain_id * 2 + @base_recovery_id_eip_155 + recovery_id
+        chain_id * 2 + @base_recovery_id_eip_155 + recovery_id0
       else
-        @base_recovery_id + recovery_id
+        @base_recovery_id + recovery_id0
       end
 
     {recovery_id, r, s}

--- a/apps/evm/lib/evm/exec_env.ex
+++ b/apps/evm/lib/evm/exec_env.ex
@@ -79,4 +79,114 @@ defmodule EVM.ExecEnv do
 
     %{exec_env | account_interface: account_interface}
   end
+
+  @doc """
+  Creates an execution environment for a create contract call.
+
+  This is defined in Eq.(88), Eq.(89), Eq.(90), Eq.(91), Eq.(92),
+  Eq.(93), Eq.(94) and Eq.(95) of the Yellow Paper.
+
+  ## Examples
+
+      iex> db = MerklePatriciaTree.Test.random_ets_db(:create_contract_exec_env)
+      iex> state = MerklePatriciaTree.Trie.new(db)
+      iex> EVM.ExecEnv.create_contract_exec_env([address: <<0x01::160>>, originator: <<0x02::160>>, gas_price: 5, sender: <<0x03::160>>, value_in_wei: 6, machine_code: <<1, 2, 3>>, stack_depth: 14, block_header: %EVM.Block.Header{nonce: 1}, state: state], Blockchain.Interface.BlockInterface, Blockchain.Interface.AccountInterface)
+      %EVM.ExecEnv{
+        address: <<0x01::160>>,
+        originator: <<0x02::160>>,
+        gas_price: 5,
+        data: <<>>,
+        sender: <<0x03::160>>,
+        value_in_wei: 6,
+        machine_code: <<1, 2, 3>>,
+        stack_depth: 14,
+        block_interface: %Blockchain.Interface.BlockInterface{block_header: %EVM.Block.Header{nonce: 1}, db: {MerklePatriciaTree.DB.ETS, :create_contract_exec_env}},
+        account_interface: %Blockchain.Interface.AccountInterface{state: %MerklePatriciaTree.Trie{db: {MerklePatriciaTree.DB.ETS, :create_contract_exec_env}, root_hash: <<86, 232, 31, 23, 27, 204, 85, 166, 255, 131, 69, 230, 146, 192, 248, 110, 91, 72, 224, 27, 153, 108, 173, 192, 1, 98, 47, 181, 227, 99, 180, 33>>}}
+      }
+  """
+
+  @spec create_contract_exec_env(
+          Keyword.t(),
+          EVM.Interface.BlockInterface.t(),
+          EVM.Interface.AccountInterface.t()
+        ) :: EVM.ExecEnv.t()
+  def create_contract_exec_env(
+        param = [
+          address: _contract_address,
+          originator: _originator,
+          gas_price: _gas_price,
+          sender: _sender,
+          value_in_wei: _endowment,
+          machine_code: _init_code,
+          stack_depth: _stack_depth,
+          block_header: block_header,
+          state: state
+        ],
+        block_interface,
+        account_interface
+      ) do
+    struct(
+      __MODULE__,
+      Keyword.merge(param,
+        data: <<>>,
+        block_interface: block_interface.new(block_header, state.db),
+        account_interface: account_interface.new(state)
+      )
+    )
+  end
+
+  @doc """
+  Creates an execution environment for a message call.
+
+  This is defined in Eq.(107), Eq.(108), Eq.(109), Eq.(110),
+  Eq.(111), Eq.(112), Eq.(113) and Eq.(114) of the Yellow Paper.
+
+  ## Examples
+
+      iex> db = MerklePatriciaTree.Test.random_ets_db(:create_message_call_exec_env)
+      iex> state = MerklePatriciaTree.Trie.new(db)
+      iex> EVM.ExecEnv.create_message_call_exec_env([sender: <<0x01::160>>, originator: <<0x02::160>>, address: <<0x03::160>>, gas_price: 4, value_in_wei: 5, data: <<1, 2, 3>>, stack_depth: 14, machine_code: <<2, 3, 4>>, block_header: %EVM.Block.Header{nonce: 1}, state: state], Blockchain.Interface.BlockInterface, Blockchain.Interface.AccountInterface)
+      %EVM.ExecEnv{
+        address: <<0x03::160>>,
+        originator: <<0x02::160>>,
+        gas_price: 4,
+        data: <<1, 2, 3>>,
+        sender: <<0x01::160>>,
+        value_in_wei: 5,
+        machine_code: <<2, 3, 4>>,
+        stack_depth: 14,
+        block_interface: %Blockchain.Interface.BlockInterface{block_header: %EVM.Block.Header{nonce: 1}, db: {MerklePatriciaTree.DB.ETS, :create_message_call_exec_env}},
+        account_interface: %Blockchain.Interface.AccountInterface{state: %MerklePatriciaTree.Trie{db: {MerklePatriciaTree.DB.ETS, :create_message_call_exec_env}, root_hash: <<86, 232, 31, 23, 27, 204, 85, 166, 255, 131, 69, 230, 146, 192, 248, 110, 91, 72, 224, 27, 153, 108, 173, 192, 1, 98, 47, 181, 227, 99, 180, 33>>}}
+      }
+  """
+
+  @spec create_message_call_exec_env(
+          Keyword.t(),
+          EVM.Interface.BlockInterface.t(),
+          EVM.Interface.AccountInterface.t()
+        ) :: EVM.ExecEnv.t()
+  def create_message_call_exec_env(
+        param = [
+          sender: _sender,
+          originator: _originator,
+          address: _recipient,
+          gas_price: _gas_price,
+          value_in_wei: _apparent_value,
+          data: _data,
+          stack_depth: _stack_depth,
+          machine_code: _machine_code,
+          block_header: block_header,
+          state: state
+        ],
+        block_interface,
+        account_interface
+      ) do
+    struct(
+      __MODULE__,
+      Keyword.merge(param,
+        block_interface: block_interface.new(block_header, state.db),
+        account_interface: account_interface.new(state)
+      )
+    )
+  end
 end

--- a/apps/evm/lib/evm/exec_env.ex
+++ b/apps/evm/lib/evm/exec_env.ex
@@ -45,53 +45,6 @@ defmodule EVM.ExecEnv do
           account_interface: EVM.Interface.AccountInterface.t()
         }
 
-  @doc """
-  Returns the base execution environment for a message call.
-  This is generally defined as equations 107-114 in the Yellow Paper.
-
-  TODO: Machine code may be passed in as a hash
-  TODO: How is block header passed in?
-
-  # TODO: Examples
-  """
-  @spec exec_env_for_message_call(
-          EVM.address(),
-          EVM.address(),
-          EVM.Gas.gas_price(),
-          binary(),
-          EVM.address(),
-          EVM.Wei.t(),
-          integer(),
-          EVM.MachineCode.t(),
-          EVM.Interface.BlockInterface.t(),
-          EVM.Interface.AccountInterface.t()
-        ) :: t
-  def exec_env_for_message_call(
-        recipient,
-        originator,
-        gas_price,
-        data,
-        sender,
-        value_in_wei,
-        stack_depth,
-        machine_code,
-        block_interface,
-        account_interface
-      ) do
-    %__MODULE__{
-      address: recipient,
-      originator: originator,
-      gas_price: gas_price,
-      data: data,
-      sender: sender,
-      value_in_wei: value_in_wei,
-      stack_depth: stack_depth,
-      machine_code: machine_code,
-      block_interface: block_interface,
-      account_interface: account_interface
-    }
-  end
-
   @spec put_storage(t(), integer(), integer()) :: t()
   def put_storage(
         exec_env = %{account_interface: account_interface, address: address},

--- a/apps/evm/lib/evm/interface/account_interface.ex
+++ b/apps/evm/lib/evm/interface/account_interface.ex
@@ -1,5 +1,6 @@
 defprotocol EVM.Interface.AccountInterface do
   alias EVM.Block.Header
+  alias Blockchain.Contract
 
   @moduledoc """
   Interface for interacting with accounts.
@@ -43,31 +44,19 @@ defprotocol EVM.Interface.AccountInterface do
 
   @spec message_call(
           t,
+          Contract.t(),
           EVM.address(),
           EVM.address(),
-          EVM.address(),
-          EVM.address(),
-          EVM.Gas.t(),
-          EVM.Gas.gas_price(),
           EVM.Wei.t(),
-          EVM.Wei.t(),
-          binary(),
-          integer(),
-          Header.t()
+          binary()
         ) :: {t, EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
   def message_call(
         t,
-        sender,
-        originator,
+        contract0,
         recipient,
         contract,
-        available_gas,
-        gas_price,
-        value,
         apparent_value,
-        data,
-        stack_depth,
-        block_header
+        data
       )
 
   @spec create_contract(

--- a/apps/evm/lib/evm/interface/account_interface.ex
+++ b/apps/evm/lib/evm/interface/account_interface.ex
@@ -1,5 +1,4 @@
 defprotocol EVM.Interface.AccountInterface do
-  alias EVM.Block.Header
   alias Blockchain.Contract
 
   @moduledoc """
@@ -61,25 +60,13 @@ defprotocol EVM.Interface.AccountInterface do
 
   @spec create_contract(
           t,
-          EVM.address(),
-          EVM.address(),
-          EVM.Gas.t(),
-          EVM.Gas.gas_price(),
-          EVM.Wei.t(),
-          EVM.MachineCode.t(),
-          integer(),
-          Header.t()
+          Contract.t() | map(),
+          EVM.MachineCode.t()
         ) :: {t, EVM.Gas.t(), EVM.SubState.t()}
   def create_contract(
         t,
-        sender,
-        originator,
-        available_gas,
-        gas_price,
-        endowment,
-        init_code,
-        stack_depth,
-        block_header
+        contract,
+        init_code
       )
 
   @spec new_contract_address(t, EVM.address(), integer()) :: EVM.address()

--- a/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
+++ b/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
@@ -19,7 +19,6 @@ defmodule EVM.Interface.Mock.MockAccountInterface do
 end
 
 defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInterface do
-  alias EVM.Block.Header
   alias Blockchain.Contract
 
   @spec account_exists?(EVM.Interface.AccountInterface.t(), EVM.address()) :: boolean()
@@ -190,25 +189,13 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
 
   @spec create_contract(
           EVM.Interface.AccountInterface.t(),
-          EVM.address(),
-          EVM.address(),
-          EVM.Gas.t(),
-          EVM.Gas.gas_price(),
-          EVM.Wei.t(),
-          EVM.MachineCode.t(),
-          integer(),
-          Header.t()
+          Contract.t(),
+          EVM.MachineCode.t()
         ) :: {EVM.Gas.t(), EVM.Interface.AccountInterface.t(), EVM.SubState.t()}
   def create_contract(
         mock_account_interface,
-        _sender,
-        _originator,
-        _available_gas,
-        _gas_price,
-        _endowment,
-        _init_code,
-        _stack_depth,
-        _block_header
+        _contract,
+        _init_code
       ) do
     {
       mock_account_interface,

--- a/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
+++ b/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
@@ -20,6 +20,7 @@ end
 
 defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInterface do
   alias EVM.Block.Header
+  alias Blockchain.Contract
 
   @spec account_exists?(EVM.Interface.AccountInterface.t(), EVM.address()) :: boolean()
   def account_exists?(mock_account_interface, address) do
@@ -165,31 +166,19 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
 
   @spec message_call(
           EVM.Interface.AccountInterface.t(),
+          Contract.t(),
           EVM.address(),
           EVM.address(),
-          EVM.address(),
-          EVM.address(),
-          EVM.Gas.t(),
-          EVM.Gas.gas_price(),
           EVM.Wei.t(),
-          EVM.Wei.t(),
-          binary(),
-          integer(),
-          Header.t()
+          binary()
         ) :: {EVM.Interface.AccountInterface.t(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
   def message_call(
         mock_account_interface,
-        _sender,
-        _originator,
+        _contract0,
         _recipient,
         _contract,
-        _available_gas,
-        _gas_price,
-        _value,
         _apparent_value,
-        _data,
-        _stack_depth,
-        _block_header
+        _data
       ) do
     {
       mock_account_interface,

--- a/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
+++ b/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
@@ -100,11 +100,11 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
   @spec put_storage(EVM.Interface.AccountInterface.t(), EVM.address(), integer(), integer()) ::
           EVM.Interface.AccountInterface.t()
   def put_storage(mock_account_interface, address, key, value) do
-    account = get_account(mock_account_interface, address)
+    account0 = get_account(mock_account_interface, address)
 
     account =
-      if account do
-        update_storage(account, key, value)
+      if account0 do
+        update_storage(account0, key, value)
       else
         new_account(%{
           storage: %{key => value}

--- a/apps/evm/lib/evm/operation/system.ex
+++ b/apps/evm/lib/evm/operation/system.ex
@@ -7,6 +7,7 @@ defmodule EVM.Operation.System do
   alias EVM.Address
   alias EVM.Stack
   alias EVM.Operation
+  alias Blockchain
 
   @dialyzer {:no_return, callcode: 2}
 
@@ -43,24 +44,22 @@ defmodule EVM.Operation.System do
       if is_allowed do
         available_gas = Helpers.all_but_one_64th(machine_state.gas)
 
+        contract = %{
+          state: nil,
+          sender: exec_env.address,
+          originator: exec_env.originator,
+          available_gas: available_gas,
+          gas_price: exec_env.gas_price,
+          stack_depth: exec_env.stack_depth + 1,
+          block_header: block_header,
+          value_in_wei: value
+        }
+
         AccountInterface.create_contract(
           exec_env.account_interface,
-          # sender
-          exec_env.address,
-          # originator
-          exec_env.originator,
-          # available_gas
-          available_gas,
-          # gas_price
-          exec_env.gas_price,
-          # endowment
-          value,
+          contract,
           # init_code
-          data,
-          # stack_depth
-          exec_env.stack_depth + 1,
-          # block_header
-          block_header
+          data
         )
       else
         {exec_env.account_interface, machine_state.gas, nil}

--- a/apps/evm/lib/evm/operation/system.ex
+++ b/apps/evm/lib/evm/operation/system.ex
@@ -29,8 +29,8 @@ defmodule EVM.Operation.System do
       %EVM.MachineState{gas: 300, stack: [0x601bcc2189b7096d8dfaa6f74efeebef20486d0d, 1], active_words: 1, memory: "________input"}
   """
   @spec create(Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()
-  def create([value, in_offset, in_size], %{exec_env: exec_env, machine_state: machine_state}) do
-    {data, machine_state} = EVM.Memory.read(machine_state, in_offset, in_size)
+  def create([value, in_offset, in_size], %{exec_env: exec_env, machine_state: machine_state0}) do
+    {data, machine_state1} = EVM.Memory.read(machine_state0, in_offset, in_size)
 
     account_balance =
       AccountInterface.get_account_balance(exec_env.account_interface, exec_env.address)
@@ -42,7 +42,7 @@ defmodule EVM.Operation.System do
 
     {updated_account_interface, _n_gas, _n_sub_state} =
       if is_allowed do
-        available_gas = Helpers.all_but_one_64th(machine_state.gas)
+        available_gas = Helpers.all_but_one_64th(machine_state1.gas)
 
         contract = %{
           state: nil,
@@ -62,7 +62,7 @@ defmodule EVM.Operation.System do
           data
         )
       else
-        {exec_env.account_interface, machine_state.gas, nil}
+        {exec_env.account_interface, machine_state1.gas, nil}
       end
 
     # Note if was exception halt or other failure on stack
@@ -77,11 +77,11 @@ defmodule EVM.Operation.System do
         0
       end
 
-    machine_state = %{machine_state | stack: Stack.push(machine_state.stack, result)}
+    machine_state2 = %{machine_state1 | stack: Stack.push(machine_state1.stack, result)}
     exec_env = %{exec_env | account_interface: updated_account_interface}
 
     %{
-      machine_state: machine_state,
+      machine_state: machine_state2,
       exec_env: exec_env
       # TODO: sub_state
     }

--- a/apps/evm/lib/evm/sub_state.ex
+++ b/apps/evm/lib/evm/sub_state.ex
@@ -44,7 +44,7 @@ defmodule EVM.SubState do
   def add_log(sub_state, address, topics, data) do
     log_entry = LogEntry.new(address, topics, data)
 
-    new_logs = sub_state.logs ++ [log_entry]
+    new_logs = Enum.reverse([log_entry | sub_state.logs])
 
     %{sub_state | logs: new_logs}
   end

--- a/apps/evm/lib/evm/vm.ex
+++ b/apps/evm/lib/evm/vm.ex
@@ -118,21 +118,21 @@ defmodule EVM.VM do
   """
   @spec cycle(MachineState.t(), SubState.t(), ExecEnv.t()) ::
           {MachineState.t(), SubState.t(), ExecEnv.t()}
-  def cycle(machine_state, sub_state, exec_env) do
-    operation = MachineCode.current_operation(machine_state, exec_env)
-    inputs = Operation.inputs(operation, machine_state)
+  def cycle(machine_state0, sub_state, exec_env) do
+    operation = MachineCode.current_operation(machine_state0, exec_env)
+    inputs = Operation.inputs(operation, machine_state0)
 
-    machine_state =
-      machine_state
+    machine_state1 =
+      machine_state0
       |> MachineState.subtract_gas(exec_env)
 
-    {machine_state, sub_state, exec_env} =
-      Operation.run_operation(operation, machine_state, sub_state, exec_env)
+    {machine_state2, sub_state, exec_env} =
+      Operation.run_operation(operation, machine_state1, sub_state, exec_env)
 
-    machine_state =
-      machine_state
+    machine_state3 =
+      machine_state2
       |> MachineState.move_program_counter(operation, inputs)
 
-    {machine_state, sub_state, exec_env}
+    {machine_state3, sub_state, exec_env}
   end
 end

--- a/apps/ex_rlp/lib/ex_rlp/decode.ex
+++ b/apps/ex_rlp/lib/ex_rlp/decode.ex
@@ -73,7 +73,7 @@ defmodule ExRLP.Decode do
   end
 
   def add_new_item(result, new_item) do
-    result ++ [new_item]
+    Enum.concat(result, [new_item])
   end
 
   @spec add_decoded_list(ExRLP.t(), binary()) :: ExRLP.t()
@@ -84,7 +84,7 @@ defmodule ExRLP.Decode do
   defp add_decoded_list(result, rlp_list_binary) do
     list_items = decode_item(rlp_list_binary, [])
 
-    result ++ [list_items]
+    Enum.concat(result, [list_items])
   end
 
   @spec decode_medium_binary(integer(), binary(), integer()) :: {binary(), binary()}

--- a/apps/ex_wire/lib/ex_wire/struct/block_queue.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/block_queue.ex
@@ -82,25 +82,25 @@ defmodule ExWire.Struct.BlockQueue do
         chain,
         db
       ) do
-    block_map = Map.get(queue, header.number, %{})
+    block_map0 = Map.get(queue, header.number, %{})
 
     {block_map, should_request_body} =
-      case Map.get(block_map, header_hash) do
+      case Map.get(block_map0, header_hash) do
         nil ->
           # may already be ready, already.
           is_empty = is_block_empty?(header)
 
-          block_map =
-            Map.put(block_map, header_hash, %{
+          block_map1 =
+            Map.put(block_map0, header_hash, %{
               commitments: MapSet.new([remote_id]),
               block: %Block{header: header},
               ready: is_empty
             })
 
-          {block_map, not is_empty}
+          {block_map1, not is_empty}
 
         block_item ->
-          {Map.put(block_map, header_hash, %{
+          {Map.put(block_map0, header_hash, %{
              block_item
              | commitments: MapSet.put(block_item.commitments, remote_id)
            }), false}

--- a/apps/ex_wire/lib/ex_wire/struct/neighbour.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/neighbour.ex
@@ -108,6 +108,6 @@ defmodule ExWire.Struct.Neighbour do
   """
   @spec encode(t) :: ExRLP.t()
   def encode(%__MODULE__{endpoint: endpoint, node: node_id}) do
-    Endpoint.encode(endpoint) ++ [node_id]
+    Enum.concat(Endpoint.encode(endpoint), [node_id])
   end
 end

--- a/apps/merkle_patricia_tree/lib/trie/builder.ex
+++ b/apps/merkle_patricia_tree/lib/trie/builder.ex
@@ -145,7 +145,7 @@ defmodule MerklePatriciaTree.Trie.Builder do
 
   # Builds a branch node with starter values
   defp build_branch(branch_options, trie) do
-    base = {:branch, for(_ <- 0..15, do: @empty_branch) ++ [<<>>]}
+    base = {:branch, Enum.concat(for(_ <- 0..15, do: @empty_branch), [<<>>])}
 
     Enum.reduce(branch_options, base, fn
       {prefix, {:encoded, value}}, {:branch, branches} ->

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,13 @@ defmodule Ethereum.MixProject do
       apps_path: "apps",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      # test_coverage: [tool: ExCoveralls],
+      # preferred_cli_env: [
+      #   coveralls: :test,
+      #   "coveralls.detail": :test,
+      #   "coveralls.post": :test,
+      #   "coveralls.html": :test
+      # ],
       dialyzer: [
         flags: [:underspecs, :unknown, :unmatched_returns],
         plt_add_apps: [:mix, :iex, :logger],
@@ -39,6 +46,7 @@ defmodule Ethereum.MixProject do
     [
       {:credo, "~> 0.10.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false}
+      # {:excoveralls, "~> 0.10", only: :test}
     ]
   end
 end


### PR DESCRIPTION
This addresses the _create_contract_  and _message_call_  arity in _Blockchain.Contract_ by combining the arguments in a struct/map. There are interfaces leading towards the execution - probably because of dependency cycles so I've left optional arguments (struct/map).