### PR TITLE
Nested modules

### DIFF
--- a/apps/abi/lib/abi/type_decoder.ex
+++ b/apps/abi/lib/abi/type_decoder.ex
@@ -6,6 +6,8 @@ defmodule ABI.TypeDecoder do
   specification.
   """
 
+  alias ExthCrypto.Math
+
   @doc """
   Decodes the given data based on the function selector.
 
@@ -253,7 +255,7 @@ defmodule ABI.TypeDecoder do
   @spec decode_uint(binary(), integer()) :: {integer(), binary()}
   defp decode_uint(data, size_in_bits) do
     # TODO: Create `left_pad` repo, err, add to `ExthCrypto.Math`
-    total_bit_size = size_in_bits + ExthCrypto.Math.mod(256 - size_in_bits, 256)
+    total_bit_size = size_in_bits + Math.mod(256 - size_in_bits, 256)
 
     <<value::integer-size(total_bit_size), rest::binary>> = data
 
@@ -263,8 +265,7 @@ defmodule ABI.TypeDecoder do
   @spec decode_bytes(binary(), integer(), atom()) :: {binary(), binary()}
   def decode_bytes(data, size_in_bytes, padding_direction) do
     # TODO: Create `unright_pad` repo, err, add to `ExthCrypto.Math`
-    total_size_in_bytes =
-      size_in_bytes + ExthCrypto.Math.mod(32 - ExthCrypto.Math.mod(size_in_bytes, 32), 32)
+    total_size_in_bytes = size_in_bytes + Math.mod(32 - Math.mod(size_in_bytes, 32), 32)
 
     padding_size_in_bytes = total_size_in_bytes - size_in_bytes
 

--- a/apps/abi/lib/abi/type_encoder.ex
+++ b/apps/abi/lib/abi/type_encoder.ex
@@ -5,6 +5,8 @@ defmodule ABI.TypeEncoder do
   array of data and encode that array according to the specification.
   """
 
+  alias ExthCrypto.Math
+
   @doc """
   Encodes the given data based on the function selector.
 
@@ -246,8 +248,7 @@ defmodule ABI.TypeEncoder do
 
   defp pad(bin, size_in_bytes, direction) do
     # TODO: Create `left_pad` repo, err, add to `ExthCrypto.Math`
-    total_size =
-      size_in_bytes + ExthCrypto.Math.mod(32 - ExthCrypto.Math.mod(size_in_bytes, 32), 32)
+    total_size = size_in_bytes + ExthCrypto.Math.mod(32 - Math.mod(size_in_bytes, 32), 32)
 
     padding_size_bits = (total_size - byte_size(bin)) * 8
     padding = <<0::size(padding_size_bits)>>

--- a/apps/blockchain/lib/blockchain/application.ex
+++ b/apps/blockchain/lib/blockchain/application.ex
@@ -4,6 +4,7 @@ defmodule Blockchain.Application do
   @moduledoc false
 
   use Application
+  alias EVM.Debugger
   require Logger
 
   def start(_type, _args) do
@@ -12,8 +13,8 @@ defmodule Blockchain.Application do
     if breakpoint_address_hex = System.get_env("BREAKPOINT") do
       case Base.decode16(breakpoint_address_hex, case: :mixed) do
         {:ok, breakpoint_address} ->
-          EVM.Debugger.enable()
-          id = EVM.Debugger.break_on(address: breakpoint_address)
+          Debugger.enable()
+          id = Debugger.break_on(address: breakpoint_address)
 
           Logger.warn(
             "Debugger has been enabled. Set breakpoint ##{id} on contract address 0x#{

--- a/apps/blockchain/lib/blockchain/interface/account_interface.ex
+++ b/apps/blockchain/lib/blockchain/interface/account_interface.ex
@@ -295,7 +295,7 @@ defimpl EVM.Interface.AccountInterface, for: Blockchain.Interface.AccountInterfa
           EVM.address(),
           EVM.Wei.t(),
           binary()
-        ) :: {EVM.Interface.AccountInterface.t(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
+        ) :: {EVM.Interface.AccountInterface.t(), EVM.Gas.t(), EVM.SubState.t(), VM.output()}
   def message_call(
         account_interface,
         %Contract{

--- a/apps/blockchain/lib/blockchain/transaction.ex
+++ b/apps/blockchain/lib/blockchain/transaction.ex
@@ -7,7 +7,10 @@ defmodule Blockchain.Transaction do
 
   alias Blockchain.Account
   alias Blockchain.Contract
+  alias Blockchain.Transaction.Signature
   alias EVM.Block.Header
+  alias EVM.Gas
+  alias EVM.MachineCode
 
   defstruct nonce: 0,
 
@@ -37,10 +40,10 @@ defmodule Blockchain.Transaction do
           gas_limit: EVM.val(),
           to: EVM.address() | <<_::0>>,
           value: EVM.val(),
-          v: Blockchain.Transaction.Signature.hash_v(),
-          r: Blockchain.Transaction.Signature.hash_r(),
-          s: Blockchain.Transaction.Signature.hash_s(),
-          init: EVM.MachineCode.t(),
+          v: Signature.hash_v(),
+          r: Signature.hash_r(),
+          s: Signature.hash_s(),
+          init: MachineCode.t(),
           data: binary()
         }
 
@@ -491,13 +494,13 @@ defmodule Blockchain.Transaction do
       iex> Blockchain.Transaction.intrinsic_gas_cost(%Blockchain.Transaction{to: <<>>, init: <<1, 2, 0, 3>>, data: <<>>}, %EVM.Block.Header{number: 5_000_000})
       3 * 68 + 4 + 32000 + 21000
   """
-  @spec intrinsic_gas_cost(t, Header.t()) :: EVM.Gas.t()
+  @spec intrinsic_gas_cost(t, Header.t()) :: Gas.t()
   def intrinsic_gas_cost(trx, block_header) do
-    EVM.Gas.g_txdata(trx.init) + EVM.Gas.g_txdata(trx.data) +
+    Gas.g_txdata(trx.init) + Gas.g_txdata(trx.data) +
       if(
         trx.to == <<>> and Header.is_after_homestead?(block_header),
-        do: EVM.Gas.g_txcreate(),
+        do: Gas.g_txcreate(),
         else: 0
-      ) + EVM.Gas.g_transaction()
+      ) + Gas.g_transaction()
   end
 end

--- a/apps/blockchain/test/blockchain/account_test.exs
+++ b/apps/blockchain/test/blockchain/account_test.exs
@@ -2,6 +2,7 @@ defmodule Blockchain.AccountTest do
   use ExUnit.Case, async: true
   doctest Blockchain.Account
   alias Blockchain.Account
+  alias MerklePatriciaTree.Test
 
   test "serialize and deserialize" do
     acct = %Account{
@@ -20,7 +21,7 @@ defmodule Blockchain.AccountTest do
   end
 
   test "valid empty state_root" do
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
     state = MerklePatriciaTree.Trie.new(db)
 
     assert state.root_hash ==
@@ -29,7 +30,7 @@ defmodule Blockchain.AccountTest do
   end
 
   test "valid state_root with one empty account" do
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
     state = MerklePatriciaTree.Trie.new(db)
 
     state =
@@ -47,7 +48,7 @@ defmodule Blockchain.AccountTest do
   end
 
   test "valid state root with an updated storage value" do
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
     address = <<0x01::160>>
     state = MerklePatriciaTree.Trie.new(db)
 
@@ -67,7 +68,7 @@ defmodule Blockchain.AccountTest do
   end
 
   test "valid state root for an account with code set" do
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
     state = MerklePatriciaTree.Trie.new(db)
     address = <<0x01::160>>
 
@@ -87,7 +88,7 @@ defmodule Blockchain.AccountTest do
   end
 
   test "valid state root after nonce has been incremented" do
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
     state = MerklePatriciaTree.Trie.new(db)
     address = <<0x01::160>>
 
@@ -107,7 +108,7 @@ defmodule Blockchain.AccountTest do
   end
 
   test "valid state root with an account balance set" do
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
     state = MerklePatriciaTree.Trie.new(db)
     address = <<0x01::160>>
 

--- a/apps/blockchain/test/blockchain/block_test.exs
+++ b/apps/blockchain/test/blockchain/block_test.exs
@@ -6,12 +6,13 @@ defmodule Blockchain.BlockTest do
   alias EVM.Block.Header
   alias Blockchain.Block
   alias Blockchain.Transaction
+  alias MerklePatriciaTree.Test
 
   eth_test("GenesisTests", :basic_genesis_tests, [:test2, :test3], fn test,
                                                                       _test_subset,
                                                                       _test_name,
                                                                       _ ->
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
 
     chain = %Blockchain.Chain{
       genesis: %{
@@ -110,7 +111,7 @@ defmodule Blockchain.BlockTest do
   end
 
   test "match genesis block on ropsten" do
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
     chain = Blockchain.Test.ropsten_chain()
 
     block =
@@ -161,7 +162,7 @@ defmodule Blockchain.BlockTest do
   end
 
   test "assert fully valid genesis block on ropsten" do
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
     chain = Blockchain.Test.ropsten_chain()
 
     Blockchain.Block.gen_genesis_block(chain, db)

--- a/apps/blockchain/test/blockchain/state_test.exs
+++ b/apps/blockchain/test/blockchain/state_test.exs
@@ -2,6 +2,7 @@ defmodule Blockchain.StateTest do
   alias MerklePatriciaTree.Trie
   alias Blockchain.Account
   alias EVM.Block.Header
+  alias MerklePatriciaTree.Test
   use EthCommonTest.Harness
   use ExUnit.Case, async: true
 
@@ -80,7 +81,7 @@ defmodule Blockchain.StateTest do
   end
 
   def account_interface(test) do
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
     empty_root_hash = ExRLP.encode(<<>>) |> BitHelper.kec()
 
     state = %Trie{

--- a/apps/blockchain/test/blockchain/transaction_test.exs
+++ b/apps/blockchain/test/blockchain/transaction_test.exs
@@ -7,6 +7,8 @@ defmodule Blockchain.TransactionTest do
 
   alias Blockchain.Transaction
   alias EVM.Block.Header
+  alias MerklePatriciaTree.Test
+  alias MerklePatriciaTree.Trie
 
   # TODO: These eth common test cases have seemed to have moved or no longer
   #       exist. We should add them back when we discover where they moved to.
@@ -173,7 +175,7 @@ defmodule Blockchain.TransactionTest do
         }
         |> Blockchain.Transaction.Signature.sign_transaction(private_key)
 
-      trie = MerklePatriciaTree.Trie.new(MerklePatriciaTree.Test.random_ets_db())
+      trie = Trie.new(Test.random_ets_db())
 
       account =
         Blockchain.Account.put_account(trie, sender, %Blockchain.Account{

--- a/apps/blockchain/test/ropsten_test.exs
+++ b/apps/blockchain/test/ropsten_test.exs
@@ -7,7 +7,9 @@ defmodule RopstenTest do
   """
 
   use ExUnit.Case, async: true
-
+  alias MerklePatriciaTree.Test
+  alias Blockchain.Blocktree
+  alias Blockchain.Test, as: BlockchainTest
   @n 11
 
   setup_all do
@@ -27,12 +29,12 @@ defmodule RopstenTest do
   end
 
   test "processing the first #{@n} blocks of the live ropsten block tree", %{blocks: blocks} do
-    db = MerklePatriciaTree.Test.random_ets_db()
-    tree = Blockchain.Blocktree.new_tree()
-    chain = Blockchain.Test.ropsten_chain()
+    db = Test.random_ets_db()
+    tree = Blocktree.new_tree()
+    chain = BlockchainTest.ropsten_chain()
 
     Enum.reduce(blocks, tree, fn block, tree ->
-      {:ok, new_tree} = Blockchain.Blocktree.verify_and_add_block(tree, chain, block, db)
+      {:ok, new_tree} = Blocktree.verify_and_add_block(tree, chain, block, db)
 
       new_tree
     end)

--- a/apps/evm/lib/evm/address.ex
+++ b/apps/evm/lib/evm/address.ex
@@ -2,6 +2,9 @@ defmodule EVM.Address do
   @moduledoc """
   EVM address functions and constants.
   """
+  alias EVM
+  alias EVM.Helpers
+
   @size 20
   @max round(:math.pow(2, @size * EVM.byte_size()))
 
@@ -25,7 +28,7 @@ defmodule EVM.Address do
   def new(address) when is_number(address) do
     address
     |> :binary.encode_unsigned()
-    |> EVM.Helpers.left_pad_bytes(@size)
+    |> Helpers.left_pad_bytes(@size)
   end
 
   @doc """
@@ -35,7 +38,7 @@ defmodule EVM.Address do
   def new(address, nonce) do
     ExRLP.encode([address, nonce])
     |> :keccakf1600.sha3_256()
-    |> EVM.Helpers.take_n_last_bytes(@size)
+    |> Helpers.take_n_last_bytes(@size)
     |> :binary.decode_unsigned()
   end
 end

--- a/apps/evm/lib/evm/builtin.ex
+++ b/apps/evm/lib/evm/builtin.ex
@@ -8,18 +8,18 @@ defmodule EVM.Builtin do
   """
 
   @spec run_ecrec(EVM.Gas.t(), EVM.ExecEnv.t()) ::
-          {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), EVM.VM.output()}
+          {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), VM.output()}
   def run_ecrec(gas, exec_env), do: {gas, %EVM.SubState{}, exec_env, <<>>}
 
   @spec run_sha256(EVM.Gas.t(), EVM.ExecEnv.t()) ::
-          {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), EVM.VM.output()}
+          {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), VM.output()}
   def run_sha256(gas, exec_env), do: {gas, %EVM.SubState{}, exec_env, <<>>}
 
   @spec run_rip160(EVM.Gas.t(), EVM.ExecEnv.t()) ::
-          {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), EVM.VM.output()}
+          {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), VM.output()}
   def run_rip160(gas, exec_env), do: {gas, %EVM.SubState{}, exec_env, <<>>}
 
   @spec run_id(EVM.Gas.t(), EVM.ExecEnv.t()) ::
-          {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), EVM.VM.output()}
+          {EVM.Gas.t(), EVM.SubState.t(), EVM.ExecEnv.t(), VM.output()}
   def run_id(gas, exec_env), do: {gas, %EVM.SubState{}, exec_env, <<>>}
 end

--- a/apps/evm/lib/evm/debugger.ex
+++ b/apps/evm/lib/evm/debugger.ex
@@ -9,7 +9,6 @@ defmodule EVM.Debugger do
   alias EVM.SubState
   alias EVM.ExecEnv
   alias EVM.MachineState
-
   require Logger
 
   @commands [
@@ -87,7 +86,7 @@ defmodule EVM.Debugger do
   def enable() do
     Application.put_env(__MODULE__, :enabled, true)
 
-    EVM.Debugger.Breakpoint.init()
+    Breakpoint.init()
   end
 
   @doc """

--- a/apps/evm/lib/evm/interface/account_interface.ex
+++ b/apps/evm/lib/evm/interface/account_interface.ex
@@ -48,7 +48,7 @@ defprotocol EVM.Interface.AccountInterface do
           EVM.address(),
           EVM.Wei.t(),
           binary()
-        ) :: {t, EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
+        ) :: {t, EVM.Gas.t(), EVM.SubState.t(), VM.output()}
   def message_call(
         t,
         contract0,

--- a/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
+++ b/apps/evm/lib/evm/interface/mock/mock_account_interface.ex
@@ -170,7 +170,7 @@ defimpl EVM.Interface.AccountInterface, for: EVM.Interface.Mock.MockAccountInter
           EVM.address(),
           EVM.Wei.t(),
           binary()
-        ) :: {EVM.Interface.AccountInterface.t(), EVM.Gas.t(), EVM.SubState.t(), EVM.VM.output()}
+        ) :: {EVM.Interface.AccountInterface.t(), EVM.Gas.t(), EVM.SubState.t(), VM.output()}
   def message_call(
         mock_account_interface,
         _contract0,

--- a/apps/evm/lib/evm/operation/sha3.ex
+++ b/apps/evm/lib/evm/operation/sha3.ex
@@ -1,7 +1,9 @@
 defmodule EVM.Operation.Sha3 do
+  alias EVM
   alias EVM.Helpers
   alias EVM.Operation
   alias EVM.Stack
+  alias EVM.Memory
 
   @doc """
   Compute Keccak-256 hash.
@@ -14,7 +16,7 @@ defmodule EVM.Operation.Sha3 do
   """
   @spec sha3(Operation.stack_args(), Operation.vm_map()) :: Operation.op_result()
   def sha3([s0, s1], %{machine_state: machine_state}) do
-    {value, machine_state} = EVM.Memory.read(machine_state, s0, s1)
+    {value, machine_state} = Memory.read(machine_state, s0, s1)
 
     hash = Helpers.encode_val(:keccakf1600.sha3_256(value))
 

--- a/apps/evm/lib/evm/operation/system.ex
+++ b/apps/evm/lib/evm/operation/system.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Operation.System do
+  alias EVM.VM
   alias EVM.MachineState
   alias EVM.ExecEnv
   alias EVM.Interface.AccountInterface
@@ -133,7 +134,7 @@ defmodule EVM.Operation.System do
       exec_env = ExecEnv.tranfer_wei_to(exec_env, to, value)
 
       {n_gas, _n_sub_state, n_exec_env, n_output} =
-        EVM.VM.run(
+        VM.run(
           call_gas,
           Map.merge(exec_env, %{
             # a

--- a/apps/evm/test/evm/vm_test.exs
+++ b/apps/evm/test/evm/vm_test.exs
@@ -2,6 +2,8 @@ defmodule EVM.VMTest do
   use ExUnit.Case, async: true
   doctest EVM.VM
 
+  alias EVM.VM
+
   setup do
     account_interface = EVM.Interface.Mock.MockAccountInterface.new()
 
@@ -29,7 +31,7 @@ defmodule EVM.VMTest do
     ]
 
     exec_env = %EVM.ExecEnv{machine_code: EVM.MachineCode.compile(instructions)}
-    result = EVM.VM.run(24, exec_env)
+    result = VM.run(24, exec_env)
 
     assert result ==
              {0, %EVM.SubState{logs: [], refund: 0, suicide_list: []}, exec_env, <<0x08::256>>}
@@ -53,7 +55,7 @@ defmodule EVM.VMTest do
       account_interface: account_interface
     }
 
-    result = EVM.VM.run(20006, exec_env)
+    result = VM.run(20006, exec_env)
 
     expected_account_state = %{
       address => %{

--- a/apps/evm/test/evm_test.exs
+++ b/apps/evm/test/evm_test.exs
@@ -2,6 +2,8 @@ defmodule EvmTest do
   alias MerklePatriciaTree.Trie
   use ExUnit.Case, async: true
 
+  alias EVM.VM
+
   @passing_tests_by_group %{
     sha3_test: :all,
     arithmetic_test: :all,
@@ -42,7 +44,7 @@ defmodule EvmTest do
     for {test_group_name, _test_group} <- @passing_tests_by_group do
       for {_test_name, test} <- passing_tests(test_group_name) do
         {gas, sub_state, exec_env, _} =
-          EVM.VM.run(hex_to_int(test["exec"]["gas"]), %EVM.ExecEnv{
+          VM.run(hex_to_int(test["exec"]["gas"]), %EVM.ExecEnv{
             account_interface: account_interface(test),
             address: hex_to_int(test["exec"]["address"]),
             block_interface: block_interface(test),

--- a/apps/ex_wire/lib/ex_wire/adapter/tcp.ex
+++ b/apps/ex_wire/lib/ex_wire/adapter/tcp.ex
@@ -15,6 +15,7 @@ defmodule ExWire.Adapter.TCP do
   alias ExWire.Framing.Frame
   alias ExWire.Handshake
   alias ExWire.Packet
+  alias ExWire.Config
 
   @ping_interval 2_000
 
@@ -72,8 +73,8 @@ defmodule ExWire.Adapter.TCP do
 
     {my_auth_msg, my_ephemeral_key_pair, my_nonce} =
       ExWire.Handshake.build_auth_msg(
-        ExWire.Config.public_key(),
-        ExWire.Config.private_key(),
+        Config.public_key(),
+        Config.private_key(),
         peer.remote_id
       )
 
@@ -386,21 +387,21 @@ defmodule ExWire.Adapter.TCP do
   # Client function to send HELLO message after connecting.
   defp send_hello(pid) do
     send_packet(pid, %Packet.Hello{
-      p2p_version: ExWire.Config.p2p_version(),
-      client_id: ExWire.Config.client_id(),
-      caps: ExWire.Config.caps(),
-      listen_port: ExWire.Config.listen_port(),
-      node_id: ExWire.Config.node_id()
+      p2p_version: Config.p2p_version(),
+      client_id: Config.client_id(),
+      caps: Config.caps(),
+      listen_port: Config.listen_port(),
+      node_id: Config.node_id()
     })
   end
 
   # Client function to send STATUS message.
   defp send_status(pid) do
     send_packet(pid, %Packet.Status{
-      protocol_version: ExWire.Config.protocol_version(),
-      network_id: ExWire.Config.network_id(),
-      total_difficulty: ExWire.Config.chain().genesis.difficulty,
-      best_hash: ExWire.Config.chain().genesis.parent_hash,
+      protocol_version: Config.protocol_version(),
+      network_id: Config.network_id(),
+      total_difficulty: Config.chain().genesis.difficulty,
+      best_hash: Config.chain().genesis.parent_hash,
       genesis_hash: <<>>
     })
     |> Exth.view("status")

--- a/apps/ex_wire/lib/ex_wire/framing/frame.ex
+++ b/apps/ex_wire/lib/ex_wire/framing/frame.ex
@@ -11,6 +11,7 @@ defmodule ExWire.Framing.Frame do
 
   alias ExthCrypto.MAC
   alias ExthCrypto.AES
+  alias ExthCrypto.Math
   alias ExWire.Framing.Secrets
 
   @type frame :: binary()
@@ -189,7 +190,7 @@ defmodule ExWire.Framing.Frame do
 
     enc = ExthCrypto.Cipher.encrypt(final, mac_secret, mac_encoder) |> Binary.take(-16)
 
-    enc_xored = ExthCrypto.Math.xor(enc, if(seed, do: seed, else: final))
+    enc_xored = Math.xor(enc, if(seed, do: seed, else: final))
 
     MAC.update(mac, enc_xored)
   end

--- a/apps/ex_wire/lib/ex_wire/framing/secrets.ex
+++ b/apps/ex_wire/lib/ex_wire/framing/secrets.ex
@@ -5,6 +5,7 @@ defmodule ExWire.Framing.Secrets do
   """
 
   alias ExthCrypto.AES
+  alias ExthCrypto.Math
   alias ExthCrypto.MAC
   alias ExthCrypto.Hash.Keccak
 
@@ -97,12 +98,12 @@ defmodule ExWire.Framing.Secrets do
 
     mac_1 =
       MAC.init(:kec)
-      |> MAC.update(ExthCrypto.Math.xor(mac_secret, remote_nonce))
+      |> MAC.update(Math.xor(mac_secret, remote_nonce))
       |> MAC.update(auth_data)
 
     mac_2 =
       MAC.init(:kec)
-      |> MAC.update(ExthCrypto.Math.xor(mac_secret, my_nonce))
+      |> MAC.update(Math.xor(mac_secret, my_nonce))
       |> MAC.update(ack_data)
 
     {egress_mac, ingress_mac} =

--- a/apps/ex_wire/lib/ex_wire/handshake/eip_8.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/eip_8.ex
@@ -7,6 +7,7 @@ defmodule ExWire.Handshake.EIP8 do
   """
 
   require Logger
+  alias ExthCrypto.Math
 
   # Amount of bytes added when encrypting with ECIES.
   # EIP Question: This is magic, isn't it? Definitely magic.
@@ -41,7 +42,7 @@ defmodule ExWire.Handshake.EIP8 do
 
     # According to EIP-8, we add padding to prevent length detection attacks. Thus, it should be
     # acceptable to pad with zero instead of random data. We opt for padding with zeros.
-    padding = ExthCrypto.Math.pad(<<>>, 100)
+    padding = Math.pad(<<>>, 100)
 
     # rlp.list(sig, initiator-pubk, initiator-nonce, auth-vsn)
     # EIP Question: Why is random appended at the end? Is this going to make it hard to upgrade the protocol?

--- a/apps/ex_wire/lib/ex_wire/handshake/message_handler.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/message_handler.ex
@@ -1,0 +1,129 @@
+defmodule ExWire.Handshake.MessageHandler do
+  alias ExWire.Config
+  alias ExWire.Handshake.Struct.AckRespV4
+  alias ExWire.Handshake.Struct.AuthMsgV4
+  alias ExWire.Handshake.EIP8
+  alias ExthCrypto.ECIES
+  alias ExthCrypto.Math
+
+  @doc """
+  Reads a given ack message, transported during the key initialization phase
+  of the RLPx protocol. This will generally be handled by the dialer of the connection.
+
+  Note: this will handle pre- or post-EIP 8 messages. We take a different approach to other
+        implementations and try EIP-8 first, and if that fails, plain.
+  """
+  @spec read_ack_resp(binary(), ExthCrypto.Key.private_key(), String.t()) ::
+          {:ok, AckRespV4.t(), binary(), binary()} | {:error, String.t()}
+  def read_ack_resp(encoded_ack, my_static_private_key, remote_addr) do
+    case EIP8.unwrap_eip_8(encoded_ack, my_static_private_key, remote_addr) do
+      {:ok, rlp, ack_resp_bin, frame_rest} ->
+        # unwrap eip-8
+        ack_resp =
+          rlp
+          |> AckRespV4.deserialize()
+
+        {:ok, ack_resp, ack_resp_bin, frame_rest}
+
+      {:error, _reason} ->
+        # TODO: reason?
+
+        # unwrap plain
+        with {:ok, plaintext} <- ECIES.decrypt(my_static_private_key, encoded_ack, <<>>, <<>>) do
+          <<
+            remote_ephemeral_public_key::binary-size(64),
+            remote_nonce::binary-size(32),
+            0x00::size(8)
+          >> = plaintext
+
+          ack_resp =
+            [
+              remote_ephemeral_public_key,
+              remote_nonce,
+              Config.protocol_version()
+            ]
+            |> AckRespV4.deserialize()
+
+          {:ok, ack_resp, encoded_ack, <<>>}
+        end
+    end
+  end
+
+  @doc """
+
+
+  TODO move to a separate module
+  Builds a response for an incoming authentication message.
+
+  ## Examples
+
+      iex> ExWire.Handshake.MessageHandler.build_ack_resp(ExthCrypto.Test.public_key(:key_c), ExthCrypto.Test.init_vector(), 32)
+      %ExWire.Handshake.Struct.AckRespV4{
+        remote_ephemeral_public_key: <<4, 146, 201, 161, 205, 19, 177, 147, 33, 107, 190, 144, 81, 145, 173, 83, 20, 105, 150, 114, 196, 249, 143, 167, 152, 63, 225, 96, 184, 86, 203, 38, 134, 241, 40, 152, 74, 34, 68, 233, 204, 91, 240, 208, 254, 62, 169, 53, 201, 248, 156, 236, 34, 203, 156, 75, 18, 121, 162, 104, 3, 164, 156, 46, 186>>,
+        remote_nonce: <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16>>,
+        remote_version: 63
+      }
+  """
+
+  @spec build_ack_resp(ExthCrypto.Key.public_key(), binary() | nil, non_neg_integer()) ::
+          AckRespV4.t()
+  def build_ack_resp(remote_ephemeral_public_key, nonce \\ nil, nonce_len) do
+    # Generate nonce unless given
+    nonce = if nonce, do: nonce, else: Math.nonce(nonce_len)
+
+    %AckRespV4{
+      remote_nonce: nonce,
+      remote_ephemeral_public_key: remote_ephemeral_public_key,
+      remote_version: Config.protocol_version()
+    }
+  end
+
+  @doc """
+
+
+  Reads a given auth message, transported during the key initialization phase
+  of the RLPx protocol. This will generally be handled by the listener of the connection.
+
+  Note: this will handle pre or post-EIP 8 messages. We take a different approach to other
+        implementations and try EIP-8 first, and if that fails, plain.
+  """
+
+  @spec read_auth_msg(binary(), Key.private_key(), String.t()) ::
+          {:ok, AuthMsgV4.t(), binary()} | {:error, String.t()}
+  def read_auth_msg(encoded_auth, my_static_private_key, remote_addr) do
+    case EIP8.unwrap_eip_8(encoded_auth, my_static_private_key, remote_addr) do
+      {:ok, rlp, _bin, frame_rest} ->
+        # unwrap eip-8
+        auth_msg =
+          rlp
+          |> AuthMsgV4.deserialize()
+          |> AuthMsgV4.set_remote_ephemeral_public_key(my_static_private_key)
+
+        {:ok, auth_msg, frame_rest}
+
+      {:error, _} ->
+        # unwrap plain
+        with {:ok, plaintext} <- ECIES.decrypt(my_static_private_key, encoded_auth, <<>>, <<>>) do
+          <<
+            signature::binary-size(65),
+            _::binary-size(32),
+            remote_public_key::binary-size(64),
+            remote_nonce::binary-size(32),
+            0x00::size(8)
+          >> = plaintext
+
+          auth_msg =
+            [
+              signature,
+              remote_public_key,
+              remote_nonce,
+              Config.protocol_version()
+            ]
+            |> AuthMsgV4.deserialize()
+            |> AuthMsgV4.set_remote_ephemeral_public_key(my_static_private_key)
+
+          {:ok, auth_msg, <<>>}
+        end
+    end
+  end
+end

--- a/apps/ex_wire/lib/ex_wire/network.ex
+++ b/apps/ex_wire/lib/ex_wire/network.ex
@@ -7,6 +7,7 @@ defmodule ExWire.Network do
 
   require Logger
 
+  alias ExWire.Config
   alias ExWire.Crypto
   alias ExWire.Handler
   alias ExWire.Protocol
@@ -258,7 +259,7 @@ defmodule ExWire.Network do
           :send,
           %{
             to: to,
-            data: Protocol.encode(message, ExWire.Config.private_key())
+            data: Protocol.encode(message, Config.private_key())
           }
         }
       )

--- a/apps/ex_wire/lib/ex_wire/packet/hello.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/hello.ex
@@ -20,6 +20,7 @@ defmodule ExWire.Packet.Hello do
   """
 
   require Logger
+  alias ExWire.Config
 
   @behaviour ExWire.Packet
 
@@ -59,9 +60,7 @@ defmodule ExWire.Packet.Hello do
       for({cap, ver} <- packet.caps, do: [cap, ver]),
       packet.listen_port,
       packet.node_id,
-      "#{ExWire.Config.local_ip() |> ExWire.Struct.Endpoint.ip_to_string()}:#{
-        ExWire.Config.listen_port()
-      }"
+      "#{Config.local_ip() |> ExWire.Struct.Endpoint.ip_to_string()}:#{Config.listen_port()}"
     ]
   end
 

--- a/apps/ex_wire/lib/ex_wire/packet/new_block.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/new_block.ex
@@ -17,6 +17,7 @@ defmodule ExWire.Packet.NewBlock do
 
   alias EVM.Block.Header
   alias ExWire.Struct.Block
+  alias ExthCrypto.Math
 
   @behaviour ExWire.Packet
 
@@ -115,7 +116,7 @@ defmodule ExWire.Packet.NewBlock do
     _ =
       Logger.debug(fn ->
         "[Packet] Peer sent new block with hash #{
-          packet.block_header |> Header.hash() |> ExthCrypto.Math.bin_to_hex()
+          packet.block_header |> Header.hash() |> Math.bin_to_hex()
         }"
       end)
 

--- a/apps/ex_wire/lib/ex_wire/packet/status.ex
+++ b/apps/ex_wire/lib/ex_wire/packet/status.ex
@@ -26,6 +26,7 @@ defmodule ExWire.Packet.Status do
   """
 
   require Logger
+  alias ExWire.Config
 
   @behaviour ExWire.Packet
 
@@ -146,7 +147,7 @@ defmodule ExWire.Packet.Status do
 
     protocol_version = packet.protocol_version
 
-    case ExWire.Config.protocol_version() do
+    case Config.protocol_version() do
       ^protocol_version ->
         :ok
 
@@ -156,7 +157,7 @@ defmodule ExWire.Packet.Status do
           Logger.debug(fn ->
             "[Packet] Disconnecting to due incompatible protocol version (them #{
               packet.protocol_version
-            }, us: #{ExWire.Config.protocol_version()})"
+            }, us: #{Config.protocol_version()})"
           end)
 
         {:disconnect, :useless_peer}

--- a/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
+++ b/apps/ex_wire/lib/ex_wire/peer_supervisor.ex
@@ -11,6 +11,8 @@ defmodule ExWire.PeerSupervisor do
   use Supervisor
 
   require Logger
+  alias ExthCrypto.Math
+  alias ExWire.Adapter.TCP
 
   @name __MODULE__
 
@@ -20,7 +22,7 @@ defmodule ExWire.PeerSupervisor do
 
   def init(_args) do
     children = [
-      worker(ExWire.Adapter.TCP, [], restart: :transient)
+      worker(TCP, [], restart: :transient)
     ]
 
     supervise(children, strategy: :simple_one_for_one)
@@ -36,7 +38,7 @@ defmodule ExWire.PeerSupervisor do
 
     for {_id, child, _type, _modules} <- Supervisor.which_children(pid) do
       # Children which are being restarted by not have a child_pid at this time.
-      if is_pid(child), do: ExWire.Adapter.TCP.send_packet(child, packet)
+      if is_pid(child), do: TCP.send_packet(child, packet)
     end
   end
 
@@ -48,7 +50,7 @@ defmodule ExWire.PeerSupervisor do
       Logger.debug(fn ->
         "[Peer Supervisor] Starting TCP connection to neighbour #{
           neighbour.endpoint.ip |> ExWire.Struct.Endpoint.ip_to_string()
-        }:#{neighbour.endpoint.tcp_port} (#{neighbour.node |> ExthCrypto.Math.bin_to_hex()})"
+        }:#{neighbour.endpoint.tcp_port} (#{neighbour.node |> Math.bin_to_hex()})"
       end)
 
     peer = ExWire.Struct.Peer.from_neighbour(neighbour)

--- a/apps/ex_wire/lib/ex_wire/struct/block_queue.ex
+++ b/apps/ex_wire/lib/ex_wire/struct/block_queue.ex
@@ -19,6 +19,8 @@ defmodule ExWire.Struct.BlockQueue do
   alias Blockchain.Blocktree
   alias Blockchain.Chain
   alias MerklePatriciaTree.Trie
+  alias MerklePatriciaTree.Test
+  alias ExWire.Config
 
   require Logger
 
@@ -324,7 +326,7 @@ defmodule ExWire.Struct.BlockQueue do
         {final_block_map, new_blocks} =
           Enum.reduce(block_map, {block_map, []}, fn {hash, block_item}, {block_map, blocks} ->
             if block_item.ready and
-                 MapSet.size(block_item.commitments) >= ExWire.Config.commitment_count() do
+                 MapSet.size(block_item.commitments) >= Config.commitment_count() do
               {Map.delete(block_map, hash), [block_item.block | blocks]}
             else
               {block_map, blocks}
@@ -375,10 +377,10 @@ defmodule ExWire.Struct.BlockQueue do
     header.transactions_root == @empty_trie and header.ommers_hash == @empty_hash
   end
 
-  @spec get_transactions_root([ExRLP.t()]) :: MerklePatriciaTree.Trie.root_hash()
+  @spec get_transactions_root([ExRLP.t()]) :: Trie.root_hash()
   defp get_transactions_root(transactions_list) do
     # this is a throw-away
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
 
     trie =
       Enum.reduce(transactions_list |> Enum.with_index(), Trie.new(db), fn {trx, i}, trie ->
@@ -397,7 +399,7 @@ defmodule ExWire.Struct.BlockQueue do
           block_map,
           BlockStruct.t(),
           ExthCrypto.hash(),
-          MerklePatriciaTree.Trie.root_hash()
+          Trie.root_hash()
         ) :: block_map
   defp reduce_block_item(
          block_map,

--- a/apps/ex_wire/lib/ex_wire/sync.ex
+++ b/apps/ex_wire/lib/ex_wire/sync.ex
@@ -14,6 +14,7 @@ defmodule ExWire.Sync do
   require Logger
 
   alias EVM.Block.Header
+  alias ExWire.Config
   alias ExWire.Struct.BlockQueue
   alias ExWire.Packet.BlockHeaders
   alias ExWire.Packet.BlockBodies
@@ -39,7 +40,7 @@ defmodule ExWire.Sync do
      %{
        block_queue: %BlockQueue{},
        block_tree: block_tree,
-       chain: ExWire.Config.chain(),
+       chain: Config.chain(),
        db: db,
        last_requested_block: request_next_block(block_tree)
      }}

--- a/apps/ex_wire/test/ex_wire/handshake/handshake_test.exs
+++ b/apps/ex_wire/test/ex_wire/handshake/handshake_test.exs
@@ -1,7 +1,16 @@
 defmodule HandshakeTest do
   use ExUnit.Case, async: true
   doctest ExWire.Handshake
+  alias ExthCrypto.Math
+  alias ExthCrypto.Key
   alias ExWire.Handshake
+  alias ExWire.Handshake.MessageHandler
+  alias Handshake.Struct.AuthMsgV4
+  alias Handshake.Struct.AckRespV4
+  alias Handshake.EIP8
+  alias ExthCrypto.Test
+
+  @nonce_len 32
 
   test "handshake build and handle auth msg / ack resp via eip-8" do
     my_static_public_key = ExthCrypto.Test.public_key(:key_a)
@@ -17,25 +26,34 @@ defmodule HandshakeTest do
 
     {:ok, encoded_auth_msg} =
       my_auth_msg
-      |> Handshake.Struct.AuthMsgV4.serialize()
-      |> Handshake.EIP8.wrap_eip_8(her_static_public_key, "1.2.3.4", my_ephemeral_key_pair)
+      |> AuthMsgV4.serialize()
+      |> EIP8.wrap_eip_8(her_static_public_key, "1.2.3.4", my_ephemeral_key_pair)
 
     {:ok, her_auth_msg, <<>>} =
-      Handshake.read_auth_msg(encoded_auth_msg, ExthCrypto.Test.private_key(:key_b), "1.2.3.4")
+      MessageHandler.read_auth_msg(
+        encoded_auth_msg,
+        ExthCrypto.Test.private_key(:key_b),
+        "1.2.3.4"
+      )
 
     # Same auth message, except we've added the remote ephemeral public key
     assert her_auth_msg.remote_ephemeral_public_key != nil
     assert my_auth_msg == %{her_auth_msg | remote_ephemeral_public_key: nil}
 
-    my_ack_resp = Handshake.build_ack_resp(her_auth_msg.remote_ephemeral_public_key)
+    my_ack_resp =
+      MessageHandler.build_ack_resp(her_auth_msg.remote_ephemeral_public_key, @nonce_len)
 
     {:ok, encoded_ack_msg} =
       my_ack_resp
-      |> Handshake.Struct.AckRespV4.serialize()
-      |> Handshake.EIP8.wrap_eip_8(her_static_public_key, "1.2.3.4", my_ephemeral_key_pair)
+      |> AckRespV4.serialize()
+      |> EIP8.wrap_eip_8(her_static_public_key, "1.2.3.4", my_ephemeral_key_pair)
 
     {:ok, her_ack_resp, _ack_bin, <<>>} =
-      Handshake.read_ack_resp(encoded_ack_msg, ExthCrypto.Test.private_key(:key_b), "1.2.3.4")
+      MessageHandler.read_ack_resp(
+        encoded_ack_msg,
+        Test.private_key(:key_b),
+        "1.2.3.4"
+      )
 
     assert my_ack_resp == her_ack_resp
   end
@@ -43,7 +61,7 @@ defmodule HandshakeTest do
   test "handshake auth plain" do
     secret =
       "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
     auth =
       """
@@ -57,23 +75,23 @@ defmodule HandshakeTest do
       a4592ee77e2bd94d0be3691f3b406f9bba9b591fc63facc016bfa8
       """
       |> String.replace("\n", "")
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
-    {:ok, auth_msg, <<>>} = Handshake.read_auth_msg(auth, secret, "1.2.3.4")
+    {:ok, auth_msg, <<>>} = MessageHandler.read_auth_msg(auth, secret, "1.2.3.4")
 
     assert auth_msg.remote_public_key ==
              "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
-             |> ExthCrypto.Math.hex_to_bin()
-             |> ExthCrypto.Key.raw_to_der()
+             |> Math.hex_to_bin()
+             |> Key.raw_to_der()
 
     assert auth_msg.remote_nonce ==
              "7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6"
-             |> ExthCrypto.Math.hex_to_bin()
+             |> Math.hex_to_bin()
 
     assert auth_msg.remote_ephemeral_public_key ==
              "654d1044b69c577a44e5f01a1209523adb4026e70c62d1c13a067acabc09d2667a49821a0ad4b634554d330a15a58fe61f8a8e0544b310c6de7b0c8da7528a8d"
-             |> ExthCrypto.Math.hex_to_bin()
-             |> ExthCrypto.Key.raw_to_der()
+             |> Math.hex_to_bin()
+             |> Key.raw_to_der()
 
     assert auth_msg.remote_version == 63
   end
@@ -81,7 +99,7 @@ defmodule HandshakeTest do
   test "handshake auth eip 8" do
     secret =
       "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
     auth =
       """
@@ -98,14 +116,14 @@ defmodule HandshakeTest do
       3bf7678318e2d5b5340c9e488eefea198576344afbdf66db5f51204a6961a63ce072c8926c
       """
       |> String.replace("\n", "")
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
-    {:ok, auth_msg, <<>>} = Handshake.read_auth_msg(auth, secret, "1.2.3.4")
+    {:ok, auth_msg, <<>>} = MessageHandler.read_auth_msg(auth, secret, "1.2.3.4")
 
     assert auth_msg.remote_public_key ==
              "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
-             |> ExthCrypto.Math.hex_to_bin()
-             |> ExthCrypto.Key.raw_to_der()
+             |> Math.hex_to_bin()
+             |> Key.raw_to_der()
 
     assert auth_msg.remote_nonce ==
              "7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6"
@@ -113,8 +131,8 @@ defmodule HandshakeTest do
 
     assert auth_msg.remote_ephemeral_public_key ==
              "654d1044b69c577a44e5f01a1209523adb4026e70c62d1c13a067acabc09d2667a49821a0ad4b634554d330a15a58fe61f8a8e0544b310c6de7b0c8da7528a8d"
-             |> ExthCrypto.Math.hex_to_bin()
-             |> ExthCrypto.Key.raw_to_der()
+             |> Math.hex_to_bin()
+             |> Key.raw_to_der()
 
     assert auth_msg.remote_version == 4
   end
@@ -122,7 +140,7 @@ defmodule HandshakeTest do
   test "handshake auth eip 8 - 2" do
     secret =
       "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
     auth =
       """
@@ -142,21 +160,21 @@ defmodule HandshakeTest do
       |> String.replace("\n", "")
       |> ExthCrypto.Math.hex_to_bin()
 
-    {:ok, auth_msg, <<>>} = Handshake.read_auth_msg(auth, secret, "1.2.3.4")
+    {:ok, auth_msg, <<>>} = MessageHandler.read_auth_msg(auth, secret, "1.2.3.4")
 
     assert auth_msg.remote_public_key ==
              "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
-             |> ExthCrypto.Math.hex_to_bin()
-             |> ExthCrypto.Key.raw_to_der()
+             |> Math.hex_to_bin()
+             |> Key.raw_to_der()
 
     assert auth_msg.remote_nonce ==
              "7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6"
-             |> ExthCrypto.Math.hex_to_bin()
+             |> Math.hex_to_bin()
 
     assert auth_msg.remote_ephemeral_public_key ==
              "654d1044b69c577a44e5f01a1209523adb4026e70c62d1c13a067acabc09d2667a49821a0ad4b634554d330a15a58fe61f8a8e0544b310c6de7b0c8da7528a8d"
-             |> ExthCrypto.Math.hex_to_bin()
-             |> ExthCrypto.Key.raw_to_der()
+             |> Math.hex_to_bin()
+             |> Key.raw_to_der()
 
     assert auth_msg.remote_version == 56
   end
@@ -164,11 +182,11 @@ defmodule HandshakeTest do
   test "handshake ack plain" do
     _remote_public_key =
       "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
     secret =
       "49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee"
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
     ack =
       """
@@ -180,17 +198,17 @@ defmodule HandshakeTest do
       d1497113d5c755e942d1
       """
       |> String.replace("\n", "")
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
-    {:ok, ack_resp, _ack_resp_bin, <<>>} = Handshake.read_ack_resp(ack, secret, "1.2.3.4")
+    {:ok, ack_resp, _ack_resp_bin, <<>>} = MessageHandler.read_ack_resp(ack, secret, "1.2.3.4")
 
     assert ack_resp.remote_nonce ==
              "559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd"
-             |> ExthCrypto.Math.hex_to_bin()
+             |> Math.hex_to_bin()
 
     assert ack_resp.remote_ephemeral_public_key ==
              "b6d82fa3409da933dbf9cb0140c5dde89f4e64aec88d476af648880f4a10e1e49fe35ef3e69e93dd300b4797765a747c6384a6ecf5db9c2690398607a86181e4"
-             |> ExthCrypto.Math.hex_to_bin()
+             |> Math.hex_to_bin()
 
     assert ack_resp.remote_version == 63
   end
@@ -198,7 +216,7 @@ defmodule HandshakeTest do
   test "handshake ack eip 8" do
     _remote_public_key =
       "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
     secret =
       "49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee"
@@ -221,17 +239,17 @@ defmodule HandshakeTest do
       5833c2464c805246155289f4
       """
       |> String.replace("\n", "")
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
-    {:ok, ack_resp, _ack_resp_bin, <<>>} = Handshake.read_ack_resp(ack, secret, "1.2.3.4")
+    {:ok, ack_resp, _ack_resp_bin, <<>>} = MessageHandler.read_ack_resp(ack, secret, "1.2.3.4")
 
     assert ack_resp.remote_nonce ==
              "559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd"
-             |> ExthCrypto.Math.hex_to_bin()
+             |> Math.hex_to_bin()
 
     assert ack_resp.remote_ephemeral_public_key ==
              "b6d82fa3409da933dbf9cb0140c5dde89f4e64aec88d476af648880f4a10e1e49fe35ef3e69e93dd300b4797765a747c6384a6ecf5db9c2690398607a86181e4"
-             |> ExthCrypto.Math.hex_to_bin()
+             |> Math.hex_to_bin()
 
     assert ack_resp.remote_version == 4
   end
@@ -239,11 +257,11 @@ defmodule HandshakeTest do
   test "handshake ack eip 8 - 2" do
     _remote_public_key =
       "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877"
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
     secret =
       "49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee"
-      |> ExthCrypto.Math.hex_to_bin()
+      |> Math.hex_to_bin()
 
     ack =
       """
@@ -264,7 +282,7 @@ defmodule HandshakeTest do
       |> String.replace("\n", "")
       |> ExthCrypto.Math.hex_to_bin()
 
-    {:ok, ack_resp, _ack_resp_bin, <<>>} = Handshake.read_ack_resp(ack, secret, "1.2.3.4")
+    {:ok, ack_resp, _ack_resp_bin, <<>>} = MessageHandler.read_ack_resp(ack, secret, "1.2.3.4")
 
     assert ack_resp.remote_nonce ==
              "559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd"

--- a/apps/ex_wire/test/ex_wire_test.exs
+++ b/apps/ex_wire/test/ex_wire_test.exs
@@ -2,6 +2,7 @@ defmodule ExWireTest do
   use ExUnit.Case
   doctest ExWire
 
+  alias ExWire.Config
   alias ExWire.Protocol
   alias ExWire.Message.Ping
   alias ExWire.Message.Pong
@@ -63,12 +64,12 @@ defmodule ExWireTest do
   end
 
   def assert_receive_message(message) do
-    message = message |> Protocol.encode(ExWire.Config.private_key())
+    message = message |> Protocol.encode(Config.private_key())
     assert_receive(%{data: ^message, to: @us})
   end
 
   def fake_send(message, timestamp) do
-    encoded_message = Protocol.encode(message, ExWire.Config.private_key())
+    encoded_message = Protocol.encode(message, Config.private_key())
 
     GenServer.cast(
       :test_network_adapter,

--- a/apps/exth_crypto/lib/ecies/ecies.ex
+++ b/apps/exth_crypto/lib/ecies/ecies.ex
@@ -11,7 +11,7 @@ defmodule ExthCrypto.ECIES do
   alias ExthCrypto.Hash
   alias ExthCrypto.Cipher
   alias ExthCrypto.KDF.NistSp80056
-
+  alias ExthCrypto.Key
   @curve_name :secp256k1
 
   @doc """
@@ -40,11 +40,11 @@ defmodule ExthCrypto.ECIES do
       # TODO: More tests
   """
   @spec encrypt(
-          ExthCrypto.Key.public_key(),
+          Key.public_key(),
           Cipher.plaintext(),
           binary(),
           binary(),
-          {ExthCrypto.Key.public_key(), ExthCrypto.Key.private_key()} | nil,
+          {Key.public_key(), Key.private_key()} | nil,
           Cipher.init_vector() | nil
         ) :: {:ok, binary()} | {:error, String.t()}
   def encrypt(
@@ -106,7 +106,7 @@ defmodule ExthCrypto.ECIES do
         MAC.mac(init_vector <> encoded_message <> shared_info_2, key_mac_hashed, params.mac)
 
       # Remove DER encoding byte
-      my_ephemeral_public_key_raw = ExthCrypto.Key.der_to_raw(my_ephemeral_public_key)
+      my_ephemeral_public_key_raw = Key.der_to_raw(my_ephemeral_public_key)
 
       # return 0x04 || R || AsymmetricEncrypt(shared-secret, plaintext) || tag
       {:ok,
@@ -133,7 +133,7 @@ defmodule ExthCrypto.ECIES do
       iex> ExthCrypto.ECIES.decrypt(ExthCrypto.Test.private_key(:key_a), ecies_encoded_msg, "shared_info_1", "shared_info_2")
       {:ok, "hello"}
   """
-  @spec decrypt(ExthCrypto.Key.private_key(), binary(), binary(), binary()) ::
+  @spec decrypt(Key.private_key(), binary(), binary(), binary()) ::
           {:ok, Cipher.plaintext()} | {:error, String.t()}
   def decrypt(
         my_static_private_key,
@@ -220,7 +220,7 @@ defmodule ExthCrypto.ECIES do
 
     # SEC1 - §5.1.4 - Steps 4, 5
     # Generate a shared secret based on our ephemeral private key and the ephemeral public key from the message
-    her_ephemeral_public_key = ExthCrypto.Key.raw_to_der(her_ephemeral_public_key_raw)
+    her_ephemeral_public_key = Key.raw_to_der(her_ephemeral_public_key_raw)
 
     shared_secret =
       ECDH.generate_shared_secret(

--- a/apps/exth_crypto/lib/ecies/parameters.ex
+++ b/apps/exth_crypto/lib/ecies/parameters.ex
@@ -20,6 +20,9 @@ defmodule ExthCrypto.ECIES.Parameters do
           key_len: integer()
         }
 
+  alias ExthCrypto.Hash.SHA
+  alias ExthCrypto.AES
+
   @doc """
   Returns curve parameters for ECIES with AES-256 symmetric
   encryption and SHA-256 hash.
@@ -28,8 +31,8 @@ defmodule ExthCrypto.ECIES.Parameters do
   def ecies_aes128_sha256 do
     %__MODULE__{
       mac: :sha256,
-      hasher: {&ExthCrypto.Hash.SHA.sha256/1, nil, 32},
-      cipher: {ExthCrypto.AES, ExthCrypto.AES.block_size(), :ctr},
+      hasher: {&SHA.sha256/1, nil, 32},
+      cipher: {AES, AES.block_size(), :ctr},
       key_len: 16
     }
   end
@@ -42,8 +45,8 @@ defmodule ExthCrypto.ECIES.Parameters do
   def ecies_aes256_sha256 do
     %__MODULE__{
       mac: :sha256,
-      hasher: {&ExthCrypto.Hash.SHA.sha256/1, nil, 32},
-      cipher: {ExthCrypto.AES, ExthCrypto.AES.block_size(), :ctr},
+      hasher: {&SHA.sha256/1, nil, 32},
+      cipher: {AES, AES.block_size(), :ctr},
       key_len: 32
     }
   end
@@ -56,8 +59,8 @@ defmodule ExthCrypto.ECIES.Parameters do
   def ecies_aes256_sha384 do
     %__MODULE__{
       mac: :sha256,
-      hasher: {&ExthCrypto.Hash.SHA.sha384/1, nil, 48},
-      cipher: {ExthCrypto.AES, ExthCrypto.AES.block_size(), :ctr},
+      hasher: {&SHA.sha384/1, nil, 48},
+      cipher: {AES, AES.block_size(), :ctr},
       key_len: 32
     }
   end
@@ -70,8 +73,8 @@ defmodule ExthCrypto.ECIES.Parameters do
   def ecies_aes256_sha512 do
     %__MODULE__{
       mac: :sha256,
-      hasher: {&ExthCrypto.Hash.SHA.sha512/1, nil, 64},
-      cipher: {ExthCrypto.AES, ExthCrypto.AES.block_size(), :ctr},
+      hasher: {&SHA.sha512/1, nil, 64},
+      cipher: {AES, AES.block_size(), :ctr},
       key_len: 32
     }
   end

--- a/apps/exth_crypto/lib/hash/hash.ex
+++ b/apps/exth_crypto/lib/hash/hash.ex
@@ -4,8 +4,9 @@ defmodule ExthCrypto.Hash do
   defined by Ethereum.
   """
 
-  # @type hash_algorithm :: :md4 | :md5 | :sha | :sha224 | :sha256 | :sha384 | :sha512 | :sha3_224 | :sha3_256 | :sha3_384 | :sha3_512
-  # @type hash_algorithms :: [:md4 | :md5 | :sha | :sha224 | :sha256 | :sha384 | :sha512 | :sha3_224 | :sha3_256 | :sha3_384 | :sha3_512]
+  alias ExthCrypto.Hash.Keccak
+  alias ExthCrypto.Hash.SHA
+
   @type hash_algorithm ::
           :md4
           | :md5
@@ -46,13 +47,13 @@ defmodule ExthCrypto.Hash do
   The SHA1 hasher.
   """
   @spec sha1() :: hash_type
-  def sha1, do: {&ExthCrypto.Hash.SHA.sha1/1, nil, 20}
+  def sha1, do: {&SHA.sha1/1, nil, 20}
 
   @doc """
   The KECCAK hasher, as defined by Ethereum.
   """
   @spec kec() :: hash_type
-  def kec, do: {&ExthCrypto.Hash.Keccak.kec/1, nil, 256}
+  def kec, do: {&Keccak.kec/1, nil, 256}
 
   @doc """
   Runs the specified hash type on the given data.

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/ets_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/ets_test.exs
@@ -2,16 +2,17 @@ defmodule MerklePatriciaTree.DB.ETSTest do
   use ExUnit.Case, async: false
   alias MerklePatriciaTree.DB
   alias MerklePatriciaTree.DB.ETS
+  alias MerklePatriciaTree.Test
 
   test "init creates an ets table" do
-    {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
+    {_, db_ref} = ETS.init(Test.random_atom(20))
 
     :ets.insert(db_ref, {"key", "value"})
     assert :ets.lookup(db_ref, "key") == [{"key", "value"}]
   end
 
   test "get/1" do
-    {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
+    {_, db_ref} = ETS.init(Test.random_atom(20))
 
     :ets.insert(db_ref, {"key", "value"})
     assert ETS.get(db_ref, "key") == {:ok, "value"}
@@ -19,7 +20,7 @@ defmodule MerklePatriciaTree.DB.ETSTest do
   end
 
   test "get!/1" do
-    db = {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
+    db = {_, db_ref} = ETS.init(Test.random_atom(20))
 
     :ets.insert(db_ref, {"key", "value"})
     assert DB.get!(db, "key") == "value"
@@ -30,7 +31,7 @@ defmodule MerklePatriciaTree.DB.ETSTest do
   end
 
   test "put!/2" do
-    {_, db_ref} = ETS.init(MerklePatriciaTree.Test.random_atom(20))
+    {_, db_ref} = ETS.init(Test.random_atom(20))
 
     assert ETS.put!(db_ref, "key", "value") == :ok
     assert :ets.lookup(db_ref, "key") == [{"key", "value"}]

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/leveldb_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/db/leveldb_test.exs
@@ -2,9 +2,10 @@ defmodule MerklePatriciaTree.DB.LevelDBTest do
   use ExUnit.Case, async: false
   alias MerklePatriciaTree.DB
   alias MerklePatriciaTree.DB.LevelDB
+  alias MerklePatriciaTree.Test
 
   test "init creates an leveldb table" do
-    db_name = "/tmp/db#{MerklePatriciaTree.Test.random_string(20)}"
+    db_name = "/tmp/db#{Test.random_string(20)}"
 
     {_, db_ref} = LevelDB.init(db_name)
     Exleveldb.close(db_ref)
@@ -12,7 +13,7 @@ defmodule MerklePatriciaTree.DB.LevelDBTest do
   end
 
   test "get/1" do
-    {_, db_ref} = LevelDB.init("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
+    {_, db_ref} = LevelDB.init("/tmp/db#{Test.random_string(20)}")
 
     Exleveldb.put(db_ref, "key", "value")
     assert LevelDB.get(db_ref, "key") == {:ok, "value"}
@@ -20,7 +21,7 @@ defmodule MerklePatriciaTree.DB.LevelDBTest do
   end
 
   test "get!/1" do
-    db = {_, db_ref} = LevelDB.init("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
+    db = {_, db_ref} = LevelDB.init("/tmp/db#{Test.random_string(20)}")
 
     Exleveldb.put(db_ref, "key", "value")
     assert DB.get!(db, "key") == "value"
@@ -31,14 +32,14 @@ defmodule MerklePatriciaTree.DB.LevelDBTest do
   end
 
   test "put!/2" do
-    {_, db_ref} = LevelDB.init("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
+    {_, db_ref} = LevelDB.init("/tmp/db#{Test.random_string(20)}")
 
     assert LevelDB.put!(db_ref, "key", "value") == :ok
     assert Exleveldb.get(db_ref, "key") == {:ok, "value"}
   end
 
   test "simple init, put, get" do
-    db = {_, db_ref} = LevelDB.init("/tmp/db#{MerklePatriciaTree.Test.random_string(20)}")
+    db = {_, db_ref} = LevelDB.init("/tmp/db#{Test.random_string(20)}")
 
     assert LevelDB.put!(db_ref, "name", "bob") == :ok
     assert DB.get!(db, "name") == "bob"

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/merkle_patricia_tree_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/merkle_patricia_tree_test.exs
@@ -2,6 +2,7 @@ defmodule MerklePatriciaTreeTest do
   use ExUnit.Case
 
   alias MerklePatriciaTree.Trie
+  alias MerklePatriciaTree.Test
 
   @passing_tests %{
     anyorder: :all,
@@ -12,7 +13,7 @@ defmodule MerklePatriciaTreeTest do
     for {test_type, test_group} <- @passing_tests do
       for {test_name, test} <- read_test_file(test_type),
           test_group == :all or Enum.member?(test_group, String.to_atom(test_name)) do
-        db = MerklePatriciaTree.Test.random_ets_db()
+        db = Test.random_ets_db()
         test_in = test["in"]
 
         input =

--- a/apps/merkle_patricia_tree/test/merkle_patricia_tree/trie_test.exs
+++ b/apps/merkle_patricia_tree/test/merkle_patricia_tree/trie_test.exs
@@ -2,13 +2,14 @@ defmodule MerklePatriciaTree.TrieTest do
   use ExUnit.Case, async: true
   doctest MerklePatriciaTree.Trie
 
+  alias MerklePatriciaTree.Test
   alias MerklePatriciaTree.Trie
   alias MerklePatriciaTree.Trie.Verifier
 
   @max_32_bits 4_294_967_296
 
   setup do
-    db = MerklePatriciaTree.Test.random_ets_db()
+    db = Test.random_ets_db()
 
     {:ok, %{db: db}}
   end
@@ -54,7 +55,7 @@ defmodule MerklePatriciaTree.TrieTest do
   end
 
   test "create trie" do
-    trie = Trie.new(MerklePatriciaTree.Test.random_ets_db())
+    trie = Trie.new(Test.random_ets_db())
 
     assert Trie.get(trie, <<0x01, 0x02, 0x03>>) == nil
   end


### PR DESCRIPTION
This PR addresses Credos warnings regarding aliases. Full module names should not be used in the code but rather aliased at the top of the module. There’s still 160 other cases left. 

This PR also includes a small refactor of functions in _ExWire.Handshake_ that ought to be private but are public. I’ve moved those functions into a separate module MessageHandler so that they can be/remain unit tested. 