### PR TITLE
Add ABI Specification Library

### DIFF
--- a/apps/abi/README.md
+++ b/apps/abi/README.md
@@ -1,4 +1,4 @@
-# ABI [![CircleCI](https://circleci.com/gh/exthereum/abi.svg?style=svg)](https://circleci.com/gh/exthereum/abi)
+# ABI
 
 The [Application Binary Interface](https://solidity.readthedocs.io/en/develop/abi-spec.html) (ABI) of Solidity describes how to transform binary data to types which the Solidity programming language understands. For instance, if we want to call a function `bark(uint32,bool)` on a Solidity-created contract `contract Dog`, what `data` parameter do we pass into our Ethereum transaction? This project allows us to encode such function calls.
 
@@ -49,6 +49,19 @@ Decode is generally the opposite of encoding, though we generally leave off the 
 ```elixir
 iex> ABI.decode("baz(uint,address)", "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000320000000000000000000000000000000000000000000000000000000000000001" |> Base.decode16!(case: :lower))
 [50, <<1::160>> |> :binary.decode_unsigned]
+```
+
+## ABI JSON
+
+You can also use the ABI JSON (produced by Solidity and other compilers) with the ABI library.
+
+```elixir
+iex> "{ \"type\": \"function\", \"name\": \"myFun\", \"inputs\": [ { \"type\": \"uint256\" } ] }"
+...> |> Poison.decode!
+...> |> ABI.Spec.load_spec()
+...> |> elem(1)
+...> |> ABI.Spec.input_function_selector()
+%ABI.FunctionSelector{function: "myFun", returns: nil, types: [uint: 256]}
 ```
 
 ## Support

--- a/apps/abi/lib/abi/spec.ex
+++ b/apps/abi/lib/abi/spec.ex
@@ -1,0 +1,135 @@
+defmodule ABI.Spec do
+  @moduledoc """
+  The ABI Specification comes from JSON files generated
+  when building an application in Solidity or other EVM-based
+  language. ABI Specifications include a list of publically
+  accessible functions and their arguments and return values.
+
+  This library parses those specifications, which it assumes
+  have already been parsed from JSON.
+  """
+
+  @type abi_entry :: %{}
+  @type abi_input :: list(abi_entry())
+
+  @type type :: String.t()
+  @type state_mutability :: nil | :view | :nonpayable
+  @type abi_type :: nil | :event | :function | :constructor | :fallback
+
+  @type io_data_type :: %{
+    type: type,
+    name: String.t(),
+    indexed: boolean(),
+  }
+
+  @type t :: %{
+    constant: boolean(),
+    inputs: list(io_data_type()),
+    name: String.t(),
+    outputs: list(io_data_type()),
+    payable: boolean(),
+    state_mutability: state_mutability(),
+    abi_type: abi_type(),
+  }
+
+  defstruct [constant: false, inputs: [], name: "", outputs: [], payable: false, state_mutability: nil, abi_type: nil]
+
+  @doc """
+  Parses an ABI specification and returns an ABI.Spec struct
+  that can be used with other library functions.
+  """
+  @spec load_specs(abi_input()) :: {:ok, list(ABI.Spec.t())} | {:error, any()}
+  def load_specs(abi_input) do
+    Enum.reduce(abi_input, {:ok, []}, fn
+      _el, err={:error, _} ->
+        err
+      abi_entry, {:ok, entries} ->
+        with {:ok, entry} <- load_spec(abi_entry) do
+          {:ok, [entry | entries]}
+        end
+    end)
+  end
+
+  @doc """
+  Parses a single ABI specification and returns an ABI.Spec struct.
+  """
+  @spec load_spec(abi_entry()) :: {:ok, ABI.Spec.t()} | {:error, any()}
+  def load_spec(abi_entry) do
+    # Note, while this doesn't currently return an errors, it makes sense
+    # to create the specification to allow it, since there are plenty
+    # of invalid cases that might be swallowed here.
+
+    {:ok, %ABI.Spec{
+      constant: abi_entry["constant"] == true,
+      name: abi_entry["name"],
+      inputs: (abi_entry["inputs"] || []) |> Enum.map(&parse_data_type/1),
+      outputs: (abi_entry["outputs"] || []) |> Enum.map(&parse_data_type/1),
+      payable: abi_entry["payable"] == true,
+      state_mutability: get_state_mutability(abi_entry["stateMutability"]),
+      abi_type: get_abi_type(abi_entry["type"]),
+    }}
+  end
+
+  @doc """
+  Returns a function selector for the input. This can be used with
+  the ABI library functions.
+  """
+  @spec input_function_selector(ABI.Spec.t()) :: ABI.FunctionSelector.t()
+  def input_function_selector(spec) do
+    types =
+      spec.inputs
+      |> Enum.map(fn entry -> entry.type end)
+      |> Enum.map(&ABI.FunctionSelector.decode_type/1)
+
+    %ABI.FunctionSelector{
+      function: spec.name,
+      types: types
+    }
+  end
+
+  @doc """
+  Returns a function selector for the output of a function. This can be used with
+  the ABI library functions.
+  """
+  @spec output_function_selector(ABI.Spec.t()) :: ABI.FunctionSelector.t()
+  def output_function_selector(spec) do
+    types =
+      spec.outputs
+      |> Enum.map(fn entry -> entry.type end)
+      |> Enum.map(&ABI.FunctionSelector.decode_type/1)
+
+    %ABI.FunctionSelector{
+      types: types
+    }
+  end
+
+  @spec parse_data_type(%{}) :: io_data_type()
+  defp parse_data_type(data_type) do
+    %{
+      name: data_type["name"],
+      type: data_type["type"],
+      indexed: data_type["indexed"] == true,
+    }
+  end
+
+  @spec get_state_mutability(String.t()) :: state_mutability()
+  defp get_state_mutability(state_mutability) do
+    case state_mutability do
+      "view" -> :view
+      "nonpayable" -> :nonpayable
+      _ -> nil
+    end
+  end
+
+  @spec get_abi_type(String.t()) :: abi_type()
+  defp get_abi_type(type) do
+    case type do
+      "function" -> :function
+      "event" -> :event
+      "fallback" -> :fallback
+      "constructor" -> :constructor
+      _ -> nil
+    end
+  end
+
+end

--- a/apps/abi/lib/abi/spec.ex
+++ b/apps/abi/lib/abi/spec.ex
@@ -17,22 +17,28 @@ defmodule ABI.Spec do
   @type abi_type :: nil | :event | :function | :constructor | :fallback
 
   @type io_data_type :: %{
-    type: type,
-    name: String.t(),
-    indexed: boolean(),
-  }
+          type: type,
+          name: String.t(),
+          indexed: boolean()
+        }
 
   @type t :: %{
-    constant: boolean(),
-    inputs: list(io_data_type()),
-    name: String.t(),
-    outputs: list(io_data_type()),
-    payable: boolean(),
-    state_mutability: state_mutability(),
-    abi_type: abi_type(),
-  }
+          constant: boolean(),
+          inputs: list(io_data_type()),
+          name: String.t(),
+          outputs: list(io_data_type()),
+          payable: boolean(),
+          state_mutability: state_mutability(),
+          abi_type: abi_type()
+        }
 
-  defstruct [constant: false, inputs: [], name: "", outputs: [], payable: false, state_mutability: nil, abi_type: nil]
+  defstruct constant: false,
+            inputs: [],
+            name: "",
+            outputs: [],
+            payable: false,
+            state_mutability: nil,
+            abi_type: nil
 
   @doc """
   Parses an ABI specification and returns an ABI.Spec struct
@@ -41,8 +47,9 @@ defmodule ABI.Spec do
   @spec load_specs(abi_input()) :: {:ok, list(ABI.Spec.t())} | {:error, any()}
   def load_specs(abi_input) do
     Enum.reduce(abi_input, {:ok, []}, fn
-      _el, err={:error, _} ->
+      _el, err = {:error, _} ->
         err
+
       abi_entry, {:ok, entries} ->
         with {:ok, entry} <- load_spec(abi_entry) do
           {:ok, [entry | entries]}
@@ -59,15 +66,16 @@ defmodule ABI.Spec do
     # to create the specification to allow it, since there are plenty
     # of invalid cases that might be swallowed here.
 
-    {:ok, %ABI.Spec{
-      constant: abi_entry["constant"] == true,
-      name: abi_entry["name"],
-      inputs: (abi_entry["inputs"] || []) |> Enum.map(&parse_data_type/1),
-      outputs: (abi_entry["outputs"] || []) |> Enum.map(&parse_data_type/1),
-      payable: abi_entry["payable"] == true,
-      state_mutability: get_state_mutability(abi_entry["stateMutability"]),
-      abi_type: get_abi_type(abi_entry["type"]),
-    }}
+    {:ok,
+     %ABI.Spec{
+       constant: abi_entry["constant"] == true,
+       name: abi_entry["name"],
+       inputs: (abi_entry["inputs"] || []) |> Enum.map(&parse_data_type/1),
+       outputs: (abi_entry["outputs"] || []) |> Enum.map(&parse_data_type/1),
+       payable: abi_entry["payable"] == true,
+       state_mutability: get_state_mutability(abi_entry["stateMutability"]),
+       abi_type: get_abi_type(abi_entry["type"])
+     }}
   end
 
   @doc """
@@ -108,7 +116,7 @@ defmodule ABI.Spec do
     %{
       name: data_type["name"],
       type: data_type["type"],
-      indexed: data_type["indexed"] == true,
+      indexed: data_type["indexed"] == true
     }
   end
 
@@ -131,5 +139,4 @@ defmodule ABI.Spec do
       _ -> nil
     end
   end
-
 end

--- a/apps/abi/test/abi/spec_test.exs
+++ b/apps/abi/test/abi/spec_test.exs
@@ -1,0 +1,197 @@
+defmodule ABI.SpecTest do
+  use ExUnit.Case, async: true
+  alias ABI.Spec
+
+  @abi_json """
+  [
+    {
+      "type": "event",
+      "name": "Failure",
+      "inputs": [
+        {
+          "type": "uint256",
+          "name": "error",
+          "indexed": false
+        },
+        {
+          "type": "uint256",
+          "name": "info",
+          "indexed": false
+        },
+        {
+          "type": "uint256",
+          "name": "detail",
+          "indexed": false
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        {
+          "type": "uint256",
+          "name": ""
+        },
+        {
+          "type": "uint256",
+          "name": ""
+        }
+      ],
+      "name": "getSupplyRate",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "_asset"
+        },
+        {
+          "type": "uint256",
+          "name": "cash"
+        },
+        {
+          "type": "uint256",
+          "name": "borrows"
+        }
+      ],
+      "constant": true
+    },
+    {
+      "type": "function",
+      "stateMutability": "view",
+      "payable": false,
+      "outputs": [
+        {
+          "type": "uint256",
+          "name": ""
+        },
+        {
+          "type": "uint256",
+          "name": ""
+        }
+      ],
+      "name": "getBorrowRate",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "_asset"
+        },
+        {
+          "type": "uint256",
+          "name": "cash"
+        },
+        {
+          "type": "uint256",
+          "name": "borrows"
+        }
+      ],
+      "constant": true
+    }
+  ]
+  """
+
+  @expected {:ok,
+             [
+               %ABI.Spec{
+                 abi_type: :function,
+                 constant: true,
+                 inputs: [
+                   %{indexed: false, name: "_asset", type: "address"},
+                   %{indexed: false, name: "cash", type: "uint256"},
+                   %{indexed: false, name: "borrows", type: "uint256"}
+                 ],
+                 name: "getBorrowRate",
+                 outputs: [
+                   %{indexed: false, name: "", type: "uint256"},
+                   %{indexed: false, name: "", type: "uint256"}
+                 ],
+                 payable: false,
+                 state_mutability: :view
+               },
+               %ABI.Spec{
+                 abi_type: :function,
+                 constant: true,
+                 inputs: [
+                   %{indexed: false, name: "_asset", type: "address"},
+                   %{indexed: false, name: "cash", type: "uint256"},
+                   %{indexed: false, name: "borrows", type: "uint256"}
+                 ],
+                 name: "getSupplyRate",
+                 outputs: [
+                   %{indexed: false, name: "", type: "uint256"},
+                   %{indexed: false, name: "", type: "uint256"}
+                 ],
+                 payable: false,
+                 state_mutability: :view
+               },
+               %ABI.Spec{
+                 abi_type: :event,
+                 constant: false,
+                 inputs: [
+                   %{indexed: false, name: "error", type: "uint256"},
+                   %{indexed: false, name: "info", type: "uint256"},
+                   %{indexed: false, name: "detail", type: "uint256"}
+                 ],
+                 name: "Failure",
+                 outputs: [],
+                 payable: false,
+                 state_mutability: nil
+               }
+             ]}
+
+  test "load/1" do
+    abi = Poison.decode!(@abi_json)
+
+    assert Spec.load_specs(abi) == @expected
+  end
+
+  test "input_function_selector/1" do
+    spec = %ABI.Spec{
+      abi_type: :function,
+      constant: true,
+      inputs: [
+        %{indexed: false, name: "_asset", type: "address"},
+        %{indexed: false, name: "cash", type: "uint256"},
+        %{indexed: false, name: "borrows", type: "uint256"}
+      ],
+      name: "getBorrowRate",
+      outputs: [
+        %{indexed: false, name: "", type: "uint256"},
+        %{indexed: false, name: "", type: "uint256"}
+      ],
+      payable: false,
+      state_mutability: :view
+    }
+
+    assert Spec.input_function_selector(spec) == %ABI.FunctionSelector{
+      function: "getBorrowRate",
+      returns: nil,
+      types: [:address, {:uint, 256}, {:uint, 256}]
+    }
+  end
+
+  test "output_function_selector/1" do
+    spec = %ABI.Spec{
+      abi_type: :function,
+      constant: true,
+      inputs: [
+        %{indexed: false, name: "_asset", type: "address"},
+        %{indexed: false, name: "cash", type: "uint256"},
+        %{indexed: false, name: "borrows", type: "uint256"}
+      ],
+      name: "getBorrowRate",
+      outputs: [
+        %{indexed: false, name: "", type: "uint256"},
+        %{indexed: false, name: "", type: "uint256"}
+      ],
+      payable: false,
+      state_mutability: :view
+    }
+
+    assert Spec.output_function_selector(spec) == %ABI.FunctionSelector{
+      returns: nil,
+      types: [{:uint, 256}, {:uint, 256}]
+    }
+  end
+end

--- a/apps/abi/test/abi/spec_test.exs
+++ b/apps/abi/test/abi/spec_test.exs
@@ -165,10 +165,10 @@ defmodule ABI.SpecTest do
     }
 
     assert Spec.input_function_selector(spec) == %ABI.FunctionSelector{
-      function: "getBorrowRate",
-      returns: nil,
-      types: [:address, {:uint, 256}, {:uint, 256}]
-    }
+             function: "getBorrowRate",
+             returns: nil,
+             types: [:address, {:uint, 256}, {:uint, 256}]
+           }
   end
 
   test "output_function_selector/1" do
@@ -190,8 +190,8 @@ defmodule ABI.SpecTest do
     }
 
     assert Spec.output_function_selector(spec) == %ABI.FunctionSelector{
-      returns: nil,
-      types: [{:uint, 256}, {:uint, 256}]
-    }
+             returns: nil,
+             types: [{:uint, 256}, {:uint, 256}]
+           }
   end
 end


### PR DESCRIPTION
This patch adds an ABI specification parser. This allows users to parse the ABI that comes out of Solidity and other Ethereum compilers and use it with the ABI library.

Overall, the ABI library needs a large re-factor, since many of the interfaces are inconsistent and there are plenty of usability issues. Overall, I think `FunctionSelector` should go away (or be reduced in scope) and we should consider using `ABI.Spec` as our proper specification. This will come in due time, but this is a first-start to making this library useful for a larger population.