### PR TITLE
Dialyzer Fixes

### DIFF
--- a/apps/abi/lib/abi/type_decoder.ex
+++ b/apps/abi/lib/abi/type_decoder.ex
@@ -263,7 +263,7 @@ defmodule ABI.TypeDecoder do
     {value, rest}
   end
 
-  @spec decode_bytes(binary(), integer(), atom()) :: {binary(), binary()}
+  @spec decode_bytes(binary(), non_neg_integer(), :left | :right) :: {binary(), binary()}
   def decode_bytes(data, size_in_bytes, padding_direction) do
     # TODO: Create `unright_pad` repo, err, add to `ExthCrypto.Math`
     total_size_in_bytes = size_in_bytes + Math.mod(32 - Math.mod(size_in_bytes, 32), 32)

--- a/apps/abi/lib/abi/type_encoder.ex
+++ b/apps/abi/lib/abi/type_encoder.ex
@@ -261,7 +261,7 @@ defmodule ABI.TypeEncoder do
     end
   end
 
-  @spec maybe_encode_unsigned(binary() | integer()) :: binary()
+  @spec maybe_encode_unsigned(binary() | non_neg_integer()) :: binary()
   defp maybe_encode_unsigned(bin) when is_binary(bin), do: bin
   defp maybe_encode_unsigned(int) when is_integer(int), do: :binary.encode_unsigned(int)
 end

--- a/apps/blockchain/lib/bit_helper.ex
+++ b/apps/blockchain/lib/bit_helper.ex
@@ -145,7 +145,7 @@ defmodule BitHelper do
       iex> BitHelper.encode_unsigned(5_000_000)
       <<76, 75, 64>>
   """
-  @spec encode_unsigned(number()) :: binary()
+  @spec encode_unsigned(non_neg_integer()) :: binary()
   def encode_unsigned(0), do: <<>>
   def encode_unsigned(n), do: :binary.encode_unsigned(n)
 
@@ -165,7 +165,7 @@ defmodule BitHelper do
       iex> BitHelper.decode_unsigned(<<76, 75, 64>>)
       5_000_000
   """
-  @spec decode_unsigned(binary()) :: number()
+  @spec decode_unsigned(binary()) :: non_neg_integer()
   def decode_unsigned(<<>>), do: 0
   def decode_unsigned(bin), do: :binary.decode_unsigned(bin)
 

--- a/apps/blockchain/lib/blockchain/blocktree.ex
+++ b/apps/blockchain/lib/blockchain/blocktree.ex
@@ -46,7 +46,12 @@ defmodule Blockchain.Blocktree do
         parent_map: %{}
       }
   """
-  @spec new_tree() :: t
+  @spec new_tree() :: %Blockchain.Blocktree{
+          :block => :root,
+          :children => %{},
+          :total_difficulty => 0,
+          :parent_map => %{}
+        }
   def new_tree() do
     %__MODULE__{
       block: :root,

--- a/apps/blockchain/lib/blockchain/chain.ex
+++ b/apps/blockchain/lib/blockchain/chain.ex
@@ -182,6 +182,6 @@ defmodule Blockchain.Chain do
     res
   end
 
-  @spec load_hex(String.t()) :: integer()
+  @spec load_hex(String.t()) :: non_neg_integer()
   defp load_hex(hex_data), do: hex_data |> load_raw_hex |> :binary.decode_unsigned()
 end

--- a/apps/blockchain/lib/eth_common_test/helpers.ex
+++ b/apps/blockchain/lib/eth_common_test/helpers.ex
@@ -42,7 +42,7 @@ defmodule EthCommonTest.Helpers do
     Base.decode16!(hex_data, case: :mixed)
   end
 
-  @spec load_hex(String.t()) :: integer()
+  @spec load_hex(String.t()) :: non_neg_integer()
   def load_hex(hex_data), do: hex_data |> load_raw_hex |> :binary.decode_unsigned()
 
   @spec read_test_file(atom(), atom()) :: any()

--- a/apps/evm/lib/evm/address.ex
+++ b/apps/evm/lib/evm/address.ex
@@ -11,7 +11,7 @@ defmodule EVM.Address do
   @doc """
   Returns the maximum allowed address size.
   """
-  @spec size() :: integer()
+  @spec size() :: 20
   def size(), do: @size
 
   @doc """
@@ -24,7 +24,7 @@ defmodule EVM.Address do
   Returns an address given an integer.
   """
 
-  @spec new(integer()) :: binary()
+  @spec new(non_neg_integer()) :: binary()
   def new(address) when is_number(address) do
     address
     |> :binary.encode_unsigned()

--- a/apps/evm/lib/evm/debugger.ex
+++ b/apps/evm/lib/evm/debugger.ex
@@ -199,7 +199,7 @@ defmodule EVM.Debugger do
   @spec break(Breakpoint.t(), MachineState.t(), SubState.t(), ExecEnv.t(), [String.t()]) ::
           {MachineState.t(), SubState.t(), ExecEnv.t()}
   def break(breakpoint, machine_state, sub_state, exec_env, input_sequence \\ []) do
-    Breakpoint.clear_pc_if_one_time_break(breakpoint.id)
+    _ = Breakpoint.clear_pc_if_one_time_break(breakpoint.id)
 
     if breakpoint.pc == :start do
       # If we're not next, we're likely a freshly hit breakpoint and should display a helpful prompt
@@ -365,9 +365,10 @@ defmodule EVM.Debugger do
          exec_env,
          input_sequence
        ) do
-    Logger.debug(fn ->
-      "Debugger output #{inspect(machine_state)} #{inspect(sub_state)} #{inspect(exec_env)}"
-    end)
+    _ =
+      Logger.debug(fn ->
+        "Debugger output #{inspect(machine_state)} #{inspect(sub_state)} #{inspect(exec_env)}"
+      end)
 
     prompt(breakpoint, machine_state, sub_state, exec_env, input_sequence)
   end
@@ -506,7 +507,7 @@ defmodule EVM.Debugger do
          exec_env,
          _input_sequence
        ) do
-    Breakpoint.set_next(breakpoint.id)
+    _ = Breakpoint.set_next(breakpoint.id)
 
     {machine_state, sub_state, exec_env}
   end

--- a/apps/evm/lib/evm/gas.ex
+++ b/apps/evm/lib/evm/gas.ex
@@ -300,7 +300,7 @@ defmodule EVM.Gas do
       222
 
   """
-  @spec operation_cost(atom(), list(EVM.val()), list(EVM.val()), MachineState.t()) :: t | nil
+  @spec operation_cost(atom(), list(EVM.val()), list(EVM.val()), MachineState.t()) :: t
   def operation_cost(operation \\ nil, inputs \\ nil, machine_state \\ nil, exec_env \\ nil)
 
   def operation_cost(:exp, [_base, exponent], _machine_state, _exec_env) do

--- a/apps/evm/lib/evm/interface/account_interface.ex
+++ b/apps/evm/lib/evm/interface/account_interface.ex
@@ -22,7 +22,7 @@ defprotocol EVM.Interface.AccountInterface do
   @spec get_account_code(t, EVM.address()) :: nil | binary()
   def get_account_code(t, address)
 
-  @spec get_account_nonce(EVM.Interface.AccountInterface.t(), EVM.address()) :: integer()
+  @spec get_account_nonce(EVM.Interface.AccountInterface.t(), EVM.address()) :: nil | integer()
   def get_account_nonce(mock_account_interface, address)
 
   @spec increment_account_nonce(t, EVM.address()) :: t

--- a/apps/evm/lib/evm/operation.ex
+++ b/apps/evm/lib/evm/operation.ex
@@ -244,7 +244,7 @@ defmodule EVM.Operation do
     apply(group_to_module(group), method, args)
   end
 
-  @spec group_to_module(atom()) :: op_result()
+  @spec group_to_module(atom()) :: atom()
   defp group_to_module(group),
     do:
       ("Elixir.EVM.Operation." <> Macro.camelize(Atom.to_string(group)))

--- a/apps/evm/lib/helpers.ex
+++ b/apps/evm/lib/helpers.ex
@@ -92,7 +92,7 @@ defmodule EVM.Helpers do
   def encode_signed(n) when n < 0, do: EVM.max_int() - abs(n)
   def encode_signed(n), do: n
 
-  @spec decode_signed(integer() | nil) :: EVM.val() | nil
+  @spec decode_signed(nil | <<_::8, _::_*8>> | non_neg_integer()) :: EVM.val()
   def decode_signed(n) when is_nil(n), do: 0
 
   def decode_signed(n) when is_integer(n) do
@@ -123,7 +123,7 @@ defmodule EVM.Helpers do
   Helper function to print an instruction message.
   """
   def inspect(msg, prefix) do
-    Logger.debug(inspect([prefix, ":", msg]))
+    _ = Logger.debug(inspect([prefix, ":", msg]))
 
     msg
   end

--- a/apps/evm/lib/math_helper.ex
+++ b/apps/evm/lib/math_helper.ex
@@ -57,7 +57,7 @@ defmodule MathHelper do
       iex> MathHelper.log(999999, 9999)
       1.500016178459417
   """
-  @spec log(number(), number()) :: number()
+  @spec log(number(), number()) :: float()
   def log(x, b), do: :math.log(x) / :math.log(b)
 
   @doc """
@@ -75,7 +75,7 @@ defmodule MathHelper do
       5
 
   """
-  @spec integer_byte_size(number()) :: number()
+  @spec integer_byte_size(number()) :: non_neg_integer()
   def integer_byte_size(n) when n == 0, do: 0
   def integer_byte_size(n), do: byte_size(:binary.encode_unsigned(n))
 
@@ -94,6 +94,6 @@ defmodule MathHelper do
       8
 
   """
-  @spec bits_to_words(number()) :: number()
+  @spec bits_to_words(number()) :: integer()
   def bits_to_words(n), do: round(:math.ceil(n / EVM.word_size()))
 end

--- a/apps/ex_rlp/lib/ex_rlp/decode.ex
+++ b/apps/ex_rlp/lib/ex_rlp/decode.ex
@@ -8,7 +8,7 @@ defmodule ExRLP.Decode do
     |> decode_item
   end
 
-  @spec maybe_decode_hex(binary(), atom()) :: binary()
+  @spec maybe_decode_hex(binary(), :binary | :hex) :: binary()
   defp maybe_decode_hex(value, :binary), do: value
   defp maybe_decode_hex(value, :hex), do: decode_hex(value)
 
@@ -87,7 +87,7 @@ defmodule ExRLP.Decode do
     Enum.concat(result, [list_items])
   end
 
-  @spec decode_medium_binary(integer(), binary(), integer()) :: {binary(), binary()}
+  @spec decode_medium_binary(1..255, binary(), 128 | 192) :: {binary(), binary()}
   defp decode_medium_binary(length_prefix, tail, prefix) do
     item_length = length_prefix - prefix
     <<item::binary-size(item_length), new_tail::binary>> = tail
@@ -95,7 +95,7 @@ defmodule ExRLP.Decode do
     {item, new_tail}
   end
 
-  @spec decode_long_binary(integer(), binary(), integer()) :: {binary(), binary()}
+  @spec decode_long_binary(1..255, binary(), 183 | 247) :: {binary(), binary()}
   defp decode_long_binary(be_size_prefix, tail, prefix) do
     be_size = be_size_prefix - prefix
     <<be::binary-size(be_size), data::binary>> = tail

--- a/apps/ex_rlp/lib/ex_rlp/encode.ex
+++ b/apps/ex_rlp/lib/ex_rlp/encode.ex
@@ -12,7 +12,7 @@ defimpl ExRLP.Encode, for: BitString do
     |> Utils.maybe_encode_hex(Keyword.get(options, :encoding, :binary))
   end
 
-  @spec encode_item(binary()) :: binary()
+  @spec encode_item(binary()) :: <<_::8, _::_*8>>
   defp encode_item(<<byte>> = item) when byte_size(item) == 1 and byte < 128 do
     item
   end
@@ -64,7 +64,7 @@ defimpl ExRLP.Encode, for: List do
     |> Utils.maybe_encode_hex(Keyword.get(options, :encoding, :binary))
   end
 
-  @spec encode_items([ExRLP.t()], binary()) :: binary()
+  @spec encode_items([ExRLP.t()], binary()) :: <<_::8, _::_*8>>
   defp encode_items([], acc) do
     acc |> prefix_list
   end
@@ -75,7 +75,7 @@ defimpl ExRLP.Encode, for: List do
     tail |> encode_items(acc <> encoded_item)
   end
 
-  @spec prefix_list(binary()) :: binary()
+  @spec prefix_list(binary()) :: <<_::8, _::_*8>>
   defp prefix_list(encoded_concat) when byte_size(encoded_concat) < 56 do
     size = encoded_concat |> byte_size
 

--- a/apps/ex_wire/lib/ex_wire/adapter/udp.ex
+++ b/apps/ex_wire/lib/ex_wire/adapter/udp.ex
@@ -28,7 +28,7 @@ defmodule ExWire.Adapter.UDP do
       :gen_udp.open(port, [{:ip, {0, 0, 0, 0}}, {:active, true}, {:reuseaddr, true}, :binary])
 
     {:ok, port_num} = :inet.port(socket)
-    Logger.debug(fn -> "[UDP] Listening on port #{port_num}" end)
+    _ = Logger.debug(fn -> "[UDP] Listening on port #{port_num}" end)
 
     {:ok, Map.put(state, :socket, socket)}
   end
@@ -69,7 +69,7 @@ defmodule ExWire.Adapter.UDP do
       )
       when not is_nil(udp_port) do
     # TODO: How should we handle invalid ping or message requests?
-    :gen_udp.send(socket, ip, udp_port, data)
+    _ = :gen_udp.send(socket, ip, udp_port, data)
 
     {:noreply, state}
   end

--- a/apps/ex_wire/lib/ex_wire/discovery.ex
+++ b/apps/ex_wire/lib/ex_wire/discovery.ex
@@ -89,9 +89,10 @@ defmodule ExWire.Discovery do
   end
 
   def handle_cast({:ping, node_id}, state) do
-    Logger.debug(fn ->
-      "[Discovery] Received ping to #{node_id |> Math.bin_to_hex()}"
-    end)
+    _ =
+      Logger.debug(fn ->
+        "[Discovery] Received ping to #{node_id |> Math.bin_to_hex()}"
+      end)
 
     # For now, do nothing.
 
@@ -99,9 +100,10 @@ defmodule ExWire.Discovery do
   end
 
   def handle_cast({:pong, node_id}, state = %{neighbours: neighbours}) do
-    Logger.debug(fn ->
-      "[Discovery] Received pong from #{node_id |> Math.bin_to_hex()}"
-    end)
+    _ =
+      Logger.debug(fn ->
+        "[Discovery] Received pong from #{node_id |> Math.bin_to_hex()}"
+      end)
 
     # If we get a pong and we like it, we should connect via TCP.
     case Enum.find(neighbours, fn neighbour -> neighbour.node == node_id end) do
@@ -109,7 +111,7 @@ defmodule ExWire.Discovery do
         Logger.debug("[Discovery] Ignoring pong, unknown node..")
 
       neighbour ->
-        Logger.debug("[Discovery] Got pong from known peer, connecting via TCP.")
+        _ = Logger.debug("[Discovery] Got pong from known peer, connecting via TCP.")
         find_neighbours(neighbour)
         PeerSupervisor.connect(neighbour)
     end
@@ -131,11 +133,12 @@ defmodule ExWire.Discovery do
         neighbour.node != Config.node_id() and not Enum.member?(known_nodes, neighbour.node)
       end)
 
-    Logger.debug(fn ->
-      "[Discovery] Hi-dilly-ho received #{Enum.count(add_neighbours.nodes)} neighboureenos, #{
-        Enum.count(new_neighbours)
-      } newerific"
-    end)
+    _ =
+      Logger.debug(fn ->
+        "[Discovery] Hi-dilly-ho received #{Enum.count(add_neighbours.nodes)} neighboureenos, #{
+          Enum.count(new_neighbours)
+        } newerific"
+      end)
 
     # For each new neighbour, send a ping
     for neighbour <- new_neighbours do
@@ -148,7 +151,7 @@ defmodule ExWire.Discovery do
 
     total_neighbours = neighbours ++ new_neighbours
 
-    Logger.debug(fn -> "[Discovery] Neighbour Count: #{Enum.count(total_neighbours)}" end)
+    _ = Logger.debug(fn -> "[Discovery] Neighbour Count: #{Enum.count(total_neighbours)}" end)
 
     {:noreply, Map.put(state, :neighbours, total_neighbours)}
   end
@@ -195,11 +198,12 @@ defmodule ExWire.Discovery do
   end
 
   defp ping_neighbour(neighbour, local_endpoint) do
-    Logger.debug(fn ->
-      "[Discovery] Initiating ping to #{inspect(neighbour, limit: :infinity)}, #{
-        inspect(local_endpoint, limit: :infinity)
-      }"
-    end)
+    _ =
+      Logger.debug(fn ->
+        "[Discovery] Initiating ping to #{inspect(neighbour, limit: :infinity)}, #{
+          inspect(local_endpoint, limit: :infinity)
+        }"
+      end)
 
     # Send a ping to each node
     ping = %Ping{

--- a/apps/ex_wire/lib/ex_wire/handler.ex
+++ b/apps/ex_wire/lib/ex_wire/handler.ex
@@ -79,7 +79,7 @@ defmodule ExWire.Handler do
   def dispatch(type, params, discovery) do
     case @handlers[type] do
       nil ->
-        Logger.warn("Message code `#{inspect(type, base: :hex)}` not implemented")
+        _ = Logger.warn("Message code `#{inspect(type, base: :hex)}` not implemented")
         :not_implemented
 
       mod when is_atom(mod) ->

--- a/apps/hex_prefix/lib/hex_prefix.ex
+++ b/apps/hex_prefix/lib/hex_prefix.ex
@@ -79,7 +79,7 @@ defmodule HexPrefix do
     iex> HexPrefix.decode(<<0x3f, 0x1c, 0xb8>>)
     {[ 15, 1, 12, 11, 8 ], true}
   """
-  @spec decode(binary()) :: {[integer()], boolean()}
+  @spec decode(<<_::8, _::_*8>>) :: {[non_neg_integer()], boolean()}
   def decode(hp) do
     # First two bits are unused, then encode terminator, then parity, then maybe first nibble, then rest
     # We just pattern match for each


### PR DESCRIPTION
# What Changed?

Fixes dailyzer warnings in
  - `apps/abi` (prior to latest ABI Spec updates)
  - `apps/ex_rlp`
  - `apps/hex_prefix`

This PR also includes low risk fixes for dialyzer warnings (i.e. small typespec changes without major refactoring).

# What Remains?

The following is a breakdown of dialyzer warnings by app.

```
apps/abi
       3
apps/blockchain
      48
grep apps/evm
      37
apps/ex_rlp
       0
grep apps/ex_wire
      25
grep apps/exth_crypto
       0
apps/hex_prefix
       0
apps/merkle_patricia_tree
       0
```

Question for the crowd. Do we have a preferred tool for project management? Are we okay using GitHub issues? If so, I'll create issues for the remaining dialyzer warnings by app.

If anyone thinks there's a better approach to tackling the remaining dialyzer warnings, any feedback is welcome! (e.g. breaking warnings down by warning type instead of app)

# Misc
In order to fix certain dailyzer warnings, some of the success typings are awkward and seem unnecessarily verbose. Does anyone have suggestions how to handle cases like the following?

```
apps/evm/lib/evm/address.ex:17:contract_supertype
Type specification is a supertype of the success typing.

Function:
EVM.Address.max/0

Type specification:
@spec max() :: integer()

Success typing:
@spec max() :: 1_461_501_637_330_902_918_203_684_832_716_283_019_655_932_542_976
```
and
```
apps/blockchain/lib/blockchain/transaction.ex:235:contract_supertype
Type specification is a supertype of the success typing.

Function:
Blockchain.Transaction.is_valid?/3

Type specification:
@spec is_valid?(EVM.state(), t(), EVM.Block.Header.t()) :: :valid | {:invalid, atom()}

Success typing:
@spec is_valid?(
  _,
  %Blockchain.Transaction{
    :data => binary(),
    :gas_limit => non_neg_integer(),
    :gas_price => non_neg_integer(),
    :init => binary(),
    :nonce => non_neg_integer(),
    :r => non_neg_integer(),
    :s => non_neg_integer(),
    :to => <<_::size(160)>>,
    :v => integer(),
    :value => non_neg_integer()
  },
  %EVM.Block.Header{
    :beneficiary => <<_::160>>,
    :difficulty => nil | integer(),
    :extra_data => binary(),
    :gas_limit => integer(),
    :gas_used => integer(),
    :logs_bloom => binary(),
    :mix_hash => nil | <<_::256>>,
    :nonce => nil | <<_::64>>,
    :number => nil | integer(),
    :ommers_hash => <<_::256>>,
    :parent_hash => <<_::256>>,
    :receipts_root => <<_::256>>,
    :state_root => <<_::256>>,
    :timestamp => nil | integer(),
    :transactions_root => <<_::256>>
  }
) ::
  :valid
  | {:invalid,
     :insufficient_balance
     | :insufficient_intrinsic_gas
     | :invalid_sender
     | :missing_account
     | :nonce_mismatch
     | :over_gas_limit}
```

# Project's Dialyzer Philosophy?

In general, some of the dialyzer warnings are rather cryptic and may require significant refactoring. What is the project's philosophy for adding warnings to a `.dialyzer.ignore-warnings` file?

@InoMurko and I spoke briefly about the goal of fixing all dialyzer issues prior to moving on to feature development. I think this is a great idea, however I think it's worth making this dialogue public (perhaps in a separate GH issue or on Gitter), then solidifying the project's philosophy for contributions in a `README.md` or `CONTRIBUTING.md` file.