### PR TITLE
fixing all credo reported moduledoc issues and removing unused functions

### DIFF
--- a/apps/evm/lib/evm/operation/block_information.ex
+++ b/apps/evm/lib/evm/operation/block_information.ex
@@ -2,6 +2,10 @@ defmodule EVM.Operation.BlockInformation do
   alias EVM.Operation
   alias EVM.Interface.BlockInterface
 
+  @moduledoc """
+  Module provides EVM OPCODE implementations for accesing block's information like timestamp, number,
+  difficulty, beneficiary address, gas and hash.
+  """
   @doc """
   Get the hash of one of the 256 most recent complete blocks.
 

--- a/apps/evm/lib/evm/operation/comparison_and_bitwise_logic.ex
+++ b/apps/evm/lib/evm/operation/comparison_and_bitwise_logic.ex
@@ -4,6 +4,10 @@ defmodule EVM.Operation.ComparisonAndBitwiseLogic do
   alias EVM.Operation
   use Bitwise
 
+  @moduledoc """
+  Module provides EVM OPCODE implementations for comparison and bitwise operations.
+  """
+
   @doc """
   Less-than comparision.
 

--- a/apps/evm/lib/evm/operation/duplication.ex
+++ b/apps/evm/lib/evm/operation/duplication.ex
@@ -1,6 +1,10 @@
 defmodule EVM.Operation.Duplication do
   alias EVM.Operation
 
+  @moduledoc """
+    Module provides EVM OPCODE implementation for duplicating items on stack.
+  """
+
   @doc """
   Duplicate stack item n-times.
 

--- a/apps/evm/lib/evm/operation/environmental_information.ex
+++ b/apps/evm/lib/evm/operation/environmental_information.ex
@@ -5,6 +5,9 @@ defmodule EVM.Operation.EnvironmentalInformation do
   alias EVM.Interface.AccountInterface
   alias EVM.Memory
 
+  @moduledoc """
+    Module provides EVM OPCODE implementations for accessing the currect account context.
+  """
   @doc """
   Get address of currently executing account.
 

--- a/apps/evm/lib/evm/operation/exchange.ex
+++ b/apps/evm/lib/evm/operation/exchange.ex
@@ -1,6 +1,10 @@
 defmodule EVM.Operation.Exchange do
   alias EVM.Operation
 
+  @moduledoc """
+    Module provides EVM OPCODE implementation for swaping items on stack.
+  """
+
   @doc """
   Swaps the first and last values on the stack.
 

--- a/apps/evm/lib/evm/operation/logging.ex
+++ b/apps/evm/lib/evm/operation/logging.ex
@@ -3,6 +3,9 @@ defmodule EVM.Operation.Logging do
   alias EVM.Memory
   alias EVM.SubState
 
+  @moduledoc """
+    Module provides EVM OPCODE log implementations (log0 to log4).
+  """
   @doc """
   Append log record with no topics.
 

--- a/apps/evm/lib/evm/operation/metadata/block_information.ex
+++ b/apps/evm/lib/evm/operation/metadata/block_information.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Operation.Metadata.BlockInformation do
+  @moduledoc false
   @operations for operation <- [
                     %{
                       id: 0x40,

--- a/apps/evm/lib/evm/operation/metadata/comparison_and_bitwise_logic.ex
+++ b/apps/evm/lib/evm/operation/metadata/comparison_and_bitwise_logic.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Operation.Metadata.ComparisonAndBitwiseLogic do
+  @moduledoc false
   @operations for operation <- [
                     %{
                       id: 0x10,

--- a/apps/evm/lib/evm/operation/metadata/duplication.ex
+++ b/apps/evm/lib/evm/operation/metadata/duplication.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Operation.Metadata.Duplication do
+  @moduledoc false
   @operations for n <- 1..17,
                   do: %EVM.Operation.Metadata{
                     # 0x80..0x8e

--- a/apps/evm/lib/evm/operation/metadata/environmental_information.ex
+++ b/apps/evm/lib/evm/operation/metadata/environmental_information.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Operation.Metadata.EnvironmentalInformation do
+  @moduledoc false
   alias EVM.Operation.Metadata
 
   @operations for operation <- [

--- a/apps/evm/lib/evm/operation/metadata/exchange.ex
+++ b/apps/evm/lib/evm/operation/metadata/exchange.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Operation.Metadata.Exchange do
+  @moduledoc false
   alias EVM.Operation.Metadata
 
   @operations for n <- 1..17,

--- a/apps/evm/lib/evm/operation/metadata/logging.ex
+++ b/apps/evm/lib/evm/operation/metadata/logging.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Operation.Metadata.Logging do
+  @moduledoc false
   @operations for n <- 0..4,
                   do: %EVM.Operation.Metadata{
                     # 0xa0 - 0xa3

--- a/apps/evm/lib/evm/operation/metadata/push.ex
+++ b/apps/evm/lib/evm/operation/metadata/push.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Operation.Metadata.Push do
+  @moduledoc false
   @operations for n <- 1..32,
                   do: %EVM.Operation.Metadata{
                     # 0x60..0x7f

--- a/apps/evm/lib/evm/operation/metadata/sha3.ex
+++ b/apps/evm/lib/evm/operation/metadata/sha3.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Operation.Metadata.SHA3 do
+  @moduledoc false
   @operations [
     %EVM.Operation.Metadata{
       id: 0x20,

--- a/apps/evm/lib/evm/operation/metadata/stack_memory_storage_and_flow.ex
+++ b/apps/evm/lib/evm/operation/metadata/stack_memory_storage_and_flow.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Operation.Metadata.StackMemoryStorageAndFlow do
+  @moduledoc false
   @operations for operation <- [
                     %{
                       id: 0x50,

--- a/apps/evm/lib/evm/operation/metadata/stop_and_arithmetic.ex
+++ b/apps/evm/lib/evm/operation/metadata/stop_and_arithmetic.ex
@@ -1,4 +1,5 @@
 defmodule EVM.Operation.Metadata.StopAndArithmetic do
+  @moduledoc false
   @operations for operation <- [
                     %{
                       id: 0x00,

--- a/apps/evm/lib/evm/operation/metadata/system.ex
+++ b/apps/evm/lib/evm/operation/metadata/system.ex
@@ -1,26 +1,10 @@
 defmodule EVM.Operation.Metadata.System do
+  @moduledoc false
   @operations for operation <- [
-                    %{
-                      id: 0xF0,
-                      description: "Create a new account with associated code.",
-                      sym: :create,
-                      input_count: 3,
-                      output_count: 1,
-                      group: :system
-                    },
                     %{
                       id: 0xF1,
                       description: "Message-call into an account.,",
                       sym: :call,
-                      input_count: 7,
-                      output_count: 1,
-                      group: :system
-                    },
-                    %{
-                      id: 0xF2,
-                      description:
-                        "Message-call into this account with an alternative account’s code.,",
-                      sym: :callcode,
                       input_count: 7,
                       output_count: 1,
                       group: :system

--- a/apps/evm/lib/evm/operation/push.ex
+++ b/apps/evm/lib/evm/operation/push.ex
@@ -2,6 +2,10 @@ defmodule EVM.Operation.Push do
   alias EVM.Operation
   alias EVM.Memory
 
+  @moduledoc """
+    Module provides EVM OPCODE implementation putting N-bytes up to a full word on stack.
+  """
+
   @doc """
   Place n-byte item on stack
 

--- a/apps/evm/lib/evm/operation/sha3.ex
+++ b/apps/evm/lib/evm/operation/sha3.ex
@@ -5,6 +5,9 @@ defmodule EVM.Operation.Sha3 do
   alias EVM.Stack
   alias EVM.Memory
 
+  @moduledoc """
+    Module provides EVM OPCODE implementation for Keccak-256 hash
+  """
   @doc """
   Compute Keccak-256 hash.
 

--- a/apps/evm/lib/evm/operation/stack_memory_storage_and_flow.ex
+++ b/apps/evm/lib/evm/operation/stack_memory_storage_and_flow.ex
@@ -7,6 +7,10 @@ defmodule EVM.Operation.StackMemoryStorageAndFlow do
   alias EVM.Operation
   use Bitwise
 
+  @moduledoc """
+    Module provides EVM OPCODE basic instruction type implementations (storage, memory and flow).
+
+  """
   @doc """
   Remove item from stack.
 

--- a/apps/evm/lib/evm/operation/stop_and_arithmetic.ex
+++ b/apps/evm/lib/evm/operation/stop_and_arithmetic.ex
@@ -4,6 +4,10 @@ defmodule EVM.Operation.StopAndArithmetic do
   alias MathHelper
   use Bitwise
 
+  @moduledoc """
+    Module provides  EVM OPCODE arithmetic implementations.
+  """
+
   @doc """
   Halts execution.
 

--- a/apps/ex_wire/lib/ex_wire/handshake/handshake.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/handshake.ex
@@ -27,33 +27,6 @@ defmodule ExWire.Handshake do
 
   @type token :: binary()
 
-  defmodule Handshake do
-    defstruct [
-      :initiator,
-      :remote_id,
-      # ecdhe-random
-      :remote_pub,
-      # nonce
-      :init_nonce,
-      #
-      :resp_nonce,
-      # ecdhe-random
-      :random_priv_key,
-      # ecdhe-random-pubk
-      :remote_random_pub
-    ]
-
-    @type t :: %__MODULE__{
-            initiator: boolean(),
-            remote_id: ExWire.node_id(),
-            remote_pub: Config.private_key(),
-            init_nonce: binary(),
-            resp_nonce: binary(),
-            random_priv_key: Config.private_key(),
-            remote_random_pub: Config.pubic_key()
-          }
-  end
-
   @nonce_len 32
 
   @doc """

--- a/apps/ex_wire/lib/ex_wire/handshake/message_handler.ex
+++ b/apps/ex_wire/lib/ex_wire/handshake/message_handler.ex
@@ -6,6 +6,10 @@ defmodule ExWire.Handshake.MessageHandler do
   alias ExthCrypto.ECIES
   alias ExthCrypto.Math
 
+  @moduledoc """
+    RLPx ECIES handshake protocol receives messages that need to be handled.
+    A helper module for ExWire.Handshake.
+  """
   @doc """
   Reads a given ack message, transported during the key initialization phase
   of the RLPx protocol. This will generally be handled by the dialer of the connection.
@@ -51,8 +55,6 @@ defmodule ExWire.Handshake.MessageHandler do
 
   @doc """
 
-
-  TODO move to a separate module
   Builds a response for an incoming authentication message.
 
   ## Examples


### PR DESCRIPTION
As of now, Credo is passing in Circle. Moduledocs are sorted, leaving only TODO's that are silenced intentionally. 